### PR TITLE
feature/atualizar_java_tomcat: migração Java 21, Tomcat 11, Jersey 4,…

### DIFF
--- a/openspec/changes/archive/2026-06-29-java-tomcat-upgrade/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-29-java-tomcat-upgrade/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-29

--- a/openspec/changes/archive/2026-06-29-java-tomcat-upgrade/design.md
+++ b/openspec/changes/archive/2026-06-29-java-tomcat-upgrade/design.md
@@ -1,0 +1,117 @@
+## Context
+
+O projeto usa Java 11, Tomcat Embed 9.0.89 (Servlet 4.0 / `javax.*`), Jersey 2.41 e Hibernate 5.6.15 (JPA 2.2 / `javax.persistence.*`). A análise completa do código revelou que a migração para Hibernate 7.4 é o trabalho mais substancial, pois o Hibernate 6+ removeu integralmente a API `Criteria` legada que é usada extensivamente no projeto.
+
+**Inventário completo de arquivos afetados:**
+
+| Arquivo | Motivo | Esforço |
+|---|---|---|
+| `pom.xml` | Tomcat 11, Jersey 4.x, Hibernate 7.4, remoção de hibernate-entitymanager | Baixo |
+| `F1ManeDados.java` | `javax.persistence.*` → `jakarta.*` | Baixo |
+| `CampeonatoSrv.java` | `javax.persistence.*` → `jakarta.*` | Baixo |
+| `CarreiraDadosSrv.java` | `javax.persistence.*` → `jakarta.*` | Baixo |
+| `CorridaCampeonatoSrv.java` | `javax.persistence.*` → `jakarta.*` | Baixo |
+| `CorridasDadosSrv.java` | `javax.persistence.*` → `jakarta.*` | Baixo |
+| `DadosCorridaCampeonatoSrv.java` | `javax.persistence.*` → `jakarta.*` | Baixo |
+| `JogadorDadosSrv.java` | `javax.persistence.*` → `jakarta.*` | Baixo |
+| `HibernateUtil.java` | `javax.persistence.*` → `jakarta.*` | Baixo |
+| `LetsRace.java` | `javax.ws.rs.*` → `jakarta.ws.rs.*` | Baixo |
+| `Compress.java` | `javax.servlet.*` → `jakarta.servlet.*` | Baixo |
+| `GZIPWriterInterceptor.java` | `javax.ws.rs.*` → `jakarta.ws.rs.*` | Baixo |
+| `ServletPaddock.java` | `javax.servlet.*` + strings `javax.persistence.jdbc.*` + `MySQL8Dialect` hard-coded | Médio |
+| `ControlePersistencia.java` | **Reescrita de 24+ métodos**: Criteria API, `saveOrUpdate()`, `org.hibernate.Query` | **Alto** |
+| `ControleClassificacao.java` | 1 `createCriteria()` + 3 `saveOrUpdate()` → `merge()` | Médio |
+| `persistence.xml` | Namespace Jakarta, versão 3.0, property keys | Baixo |
+| `Dockerfile` | Imagem base JRE 11 → 21 | Baixo |
+
+## Goals / Non-Goals
+
+**Goals:**
+- Java 21 LTS como versão do compilador e runtime
+- Tomcat 11.x (Jakarta Servlet 6.1)
+- Jersey 4.x (`jakarta.ws.rs`) — necessário para Servlet 6.1
+- Hibernate 7.4 (`jakarta.persistence` 3.2)
+- Todos os imports `javax.*` migrados para `jakarta.*`
+- `ControlePersistencia.java` com queries em HQL tipado (sem Criteria legada)
+- `session.saveOrUpdate()` substituído por `session.merge()` em todo o código
+- `persistence.xml` com namespace Jakarta e property keys atualizadas
+- Imagem Docker base em JRE 21
+
+**Non-Goals:**
+- Adotar recursos de linguagem Java 21 no código existente (records, virtual threads, etc.)
+- Migrar para Jakarta CDI ou outro container de injeção
+- Migrar as queries de HQL para JPA Criteria API moderna (opcional, pós-migração)
+- Alterar lógica de negócio do jogo
+
+## Decisions
+
+### D1: Java 21 LTS (não Java 17 ou 24)
+Java 21 é o LTS mais recente com suporte garantido até 2031. Java 17 já é LTS anterior; Java 24 não é LTS.
+
+### D2: Tomcat 11.x (Jakarta EE 11 / Servlet 6.1)
+Tomcat 11 implementa Jakarta EE 11 (Servlet 6.1) e é necessário para rodar Hibernate 7.4, que requer Jakarta Persistence 3.2. Tomcat 10.1 (Jakarta EE 10) não suporta Jakarta Persistence 3.2 e não é compatível com Hibernate 7.x.
+
+### D3: Hibernate 7.4 (não 6.x)
+Hibernate 7.x requer Jakarta Persistence 3.2 (Jakarta EE 11), alinhado com Tomcat 11. Hibernate 6.x usa Jakarta Persistence 3.1 (Jakarta EE 10) e não é compatível com o stack completo Jakarta EE 11. Indo direto para 7.4 evita um upgrade intermediário desnecessário. O impacto no código é o mesmo — a API Criteria legada já foi removida no Hibernate 6 e `saveOrUpdate` também, portanto a reescrita de `ControlePersistencia.java` é idêntica independentemente de ir para 6.x ou 7.4.
+
+### D4: Reescrever Criteria API legada para HQL (não para JPA Criteria API moderna)
+O Hibernate 6 removeu completamente `session.createCriteria()`, `Restrictions`, `Order` e `org.hibernate.Criteria`. A substituição mais direta e de menor risco é HQL (`session.createQuery("from Entidade where campo = :param", Entidade.class)`), que:
+- Preserva a semântica das queries originais
+- É familiar para quem já lê o código atual
+- Requer menos refatoração estrutural do que migrar para JPA Criteria Builder
+
+Alternativa considerada: JPA Criteria API moderna — descartada para este upgrade por aumentar significativamente o esforço sem benefício funcional imediato.
+
+### D5: `saveOrUpdate()` → `merge()` (não `persist()`)
+`session.merge()` tem semântica equivalente ao `saveOrUpdate()` do Hibernate 5 (insere se novo, atualiza se existente). `session.persist()` lança exceção se o objeto já tem ID.
+
+### D6: Trocar `GenerationType.AUTO` por `IDENTITY` nas entidades
+O `GenerationType.AUTO` no Hibernate 6 usa SEQUENCE por padrão, comportamento diferente do Hibernate 5 com MySQL (que usava `AUTO_INCREMENT` / IDENTITY). Como não há banco legado a preservar, a estratégia mais simples e explícita é trocar `AUTO` por `IDENTITY` em `F1ManeDados.java`, alinhando o comportamento com o `AUTO_INCREMENT` do MySQL e eliminando qualquer ambiguidade entre ambientes.
+
+### D7: Jersey 4.x (não 3.x)
+Jersey 3.x foi construído para Servlet 6.0 (Jakarta EE 10). Tomcat 11 usa Servlet 6.1 (Jakarta EE 11) — Jersey 4.x é a versão correta para este stack. As anotações `jakarta.ws.rs.*` usadas no código (`@GET`, `@POST`, `@Path`, `@Produces`, etc.) são as mesmas entre Jersey 3 e 4: não há mudança de código, apenas de versão dos artefatos no `pom.xml`.
+
+## Risks / Trade-offs
+
+- **[Risco baixo] `GenerationType.AUTO` → trocado por `IDENTITY`** → Sem banco legado, a troca é direta. `IDENTITY` mapeia explicitamente para `AUTO_INCREMENT` no MySQL e para `IDENTITY` no H2 — comportamento previsível em ambos os ambientes.
+- **[RISCO ALTO] `ControlePersistencia.java` é a classe central da persistência** — Tem 24+ métodos que precisam ser reescritos. Qualquer erro de migration pode corromper dados ou causar falhas silenciosas. Cada método deve ser testado individualmente após migração.
+- **[Risco médio] `SchemaExport` em `ServletPaddock.java`** → A API de bootstrapping do Hibernate 6 manteve `MetadataSources` e `StandardServiceRegistryBuilder`, mas `SchemaExport` pode ter sofrido mudanças menores. A funcionalidade de `createSchema` é administrativa (acesso por senha) — testar separadamente.
+- **[Risco médio] Dependências transitivas com `javax.*`** → Verificar `mvn dependency:tree` para garantir que nenhuma lib ainda puxa `javax.servlet-api`, `javax.ws.rs-api` ou `javax.persistence-api`.
+- **[Risco médio] `hibernate-entitymanager` como transitiva** → Mesmo removendo do `pom.xml` direto, outra lib pode puxá-lo. Verificar com `mvn dependency:tree | grep hibernate-entitymanager` após upgrade.
+- **[Trade-off] JDK 21 obrigatório em todos os ambientes de build** → Desenvolvedores e CI precisam de JDK 21 instalado.
+- **[Risco baixo] `MySQL8Dialect` em dois lugares** → Está no `pom.xml` (via profile) e hard-coded em `ServletPaddock.getMetaData()` como string literal. Atualizar os dois.
+
+## Migration Plan
+
+### Fase 1 — pom.xml e namespace (baixo risco, não muda comportamento)
+1. Atualizar `maven.compiler.release` para `21`
+2. Atualizar Tomcat para 11.x, Jersey para 4.x, Hibernate para 7.4; remover `hibernate-entitymanager`; trocar `jakarta.servlet-api` para 6.1
+3. Migrar imports `javax.*` → `jakarta.*` nos 12 arquivos de namespace
+4. Atualizar `persistence.xml` (namespace Jakarta, versão `3.2`, property keys, dialeto)
+5. Atualizar strings em `ServletPaddock.java`
+6. Atualizar Dockerfile
+7. Verificar `mvn dependency:tree` para transitivas com `javax.*`
+8. Compilar: `mvn clean package -Ph2 -DskipTests` — deve compilar sem erros
+
+### Fase 2 — Reescrita de queries (alto risco, testar com cuidado)
+9. Reescrever todos os 24+ métodos de `ControlePersistencia.java`:
+   - `session.createCriteria(X).add(Restrictions.eq("campo", val)).list()` → `session.createQuery("from X where campo = :p", X.class).setParameter("p", val).list()`
+   - `session.saveOrUpdate(obj)` → `session.merge(obj)`
+   - `org.hibernate.Query` → `session.createQuery(hql, Type.class)`
+   - `createAlias()` → JPA JOIN em HQL
+   - `criteria.uniqueResult()` → `.uniqueResultOptional().orElse(null)` ou `.getSingleResultOrNull()`
+10. Reescrever método `obterListaClassificacao()` em `ControleClassificacao.java`
+11. Substituir 3 `saveOrUpdate()` em `ControleClassificacao.java` por `merge()`
+12. Verificar API de `SchemaExport` em `ServletPaddock.createSchema()`
+
+### Fase 3 — Validação
+13. Compilar com testes: `mvn clean package -Ph2`
+14. Subir servidor, testar endpoint REST e persistência de dados
+
+**Rollback**: revert no `pom.xml`, nos arquivos Java e no `persistence.xml`.
+
+## Open Questions
+
+- O CI usa JDK 11 explicitamente? Se sim, precisa ser atualizado para JDK 21.
+- O `Dockerfile` usa qual imagem base exatamente (`eclipse-temurin`, `openjdk`, outra)?
+- A funcionalidade de `createSchema` em `ServletPaddock` é usada ativamente ou é apenas utilitário administrativo?

--- a/openspec/changes/archive/2026-06-29-java-tomcat-upgrade/proposal.md
+++ b/openspec/changes/archive/2026-06-29-java-tomcat-upgrade/proposal.md
@@ -1,0 +1,55 @@
+## Why
+
+O projeto usa Java 11, Tomcat 9 (Servlet 4.0 / `javax.*`) e Hibernate 5.6 (JPA 2.2 / `javax.persistence.*`), todos fora do ciclo de suporte ativo. A migração para **Java 21 LTS + Tomcat 11 (Jakarta EE 11) + Hibernate 7.4** atualiza o projeto para o stack mais recente e suportado, trazendo ganhos de performance, segurança e acesso a APIs modernas da linguagem.
+
+A análise do código revelou que a migração do Hibernate é o trabalho mais substancial: a partir do Hibernate 6, a API `Criteria` legada foi completamente removida — ela é usada em 24+ métodos de `ControlePersistencia.java` — e `saveOrUpdate()` também foi removido. Toda a camada de queries precisa ser reescrita.
+
+## What Changes
+
+- Compilador: Java 11 → **Java 21 LTS**
+- `tomcat-embed-jasper`: 9.0.x → **11.x** (Jakarta EE 11 / Servlet 6.1)
+- `javax.servlet-api 4.0.1` → **`jakarta.servlet-api 6.1`**
+- Jersey: 2.41 (`javax.ws.rs`) → **4.x** (`jakarta.ws.rs`) — necessário para Servlet 6.1
+- `hibernate-core`: 5.6.15 → **7.4** (Jakarta Persistence 3.2)
+- `hibernate-entitymanager` **removido** — fundido em `hibernate-core` a partir do Hibernate 6
+- Todos os imports `javax.servlet.*`, `javax.ws.rs.*`, `javax.inject.*` e `javax.persistence.*` migrados para `jakarta.*`
+- `persistence.xml`: namespace, versão (`3.2`) e property keys atualizados para Jakarta Persistence 3.2
+- `ControlePersistencia.java`: 24+ métodos reescritos de Criteria API legada para HQL tipado
+- `session.saveOrUpdate()` → `session.merge()` em todas as ocorrências
+- `org.hibernate.Query` (legado) → `session.createQuery(hql, Tipo.class)` tipado
+- `MySQL8Dialect` → `MySQLDialect` (renomeado no Hibernate 6+)
+- `GenerationType.AUTO` → `GenerationType.IDENTITY` em `F1ManeDados.java`
+- Imagem Docker base: JRE 11 → **JRE 21**
+
+## Capabilities
+
+### New Capabilities
+
+- `java-tomcat-upgrade`: Roteiro de migração completo para Java 21 + Tomcat 11 + Hibernate 7.4
+
+### Modified Capabilities
+
+- `sdd-execution-modes`: Modo servidor web migra de Tomcat 9 (`javax.*`) para Tomcat 11 (`jakarta.*` / Servlet 6.1); comportamento externo não muda
+- `sdd-persistence`: Hibernate 5 → 7.4 com migração de namespace JPA, remoção da API Criteria legada e reescrita da camada de queries
+
+## Impact
+
+**`pom.xml`** (1 arquivo):
+- Tomcat 11.x, Jersey 4.x, `jakarta.servlet-api 6.1`, `hibernate-core 7.4`; remoção de `hibernate-entitymanager`; `maven.compiler.release=21`
+
+**Código Java — troca de namespace `javax.*` → `jakarta.*`** (12 arquivos, baixo esforço):
+- 7 entidades JPA: `F1ManeDados`, `CampeonatoSrv`, `CarreiraDadosSrv`, `CorridaCampeonatoSrv`, `CorridasDadosSrv`, `DadosCorridaCampeonatoSrv`, `JogadorDadosSrv`
+- `HibernateUtil.java`
+- `LetsRace.java`, `Compress.java`, `GZIPWriterInterceptor.java`
+- `ServletPaddock.java` (imports + strings hardcoded `"javax.persistence.jdbc.*"` + dialeto MySQL)
+
+**Código Java — reescrita de queries Hibernate** (2 arquivos, alto esforço):
+- `ControlePersistencia.java`: 24+ métodos com `createCriteria()`, `Restrictions`, `Order`, `saveOrUpdate()`, `org.hibernate.Query` — reescritos para HQL tipado e `merge()`
+- `ControleClassificacao.java`: 1 `createCriteria()` e 3 `saveOrUpdate()` → `merge()`
+
+**Config** (1 arquivo):
+- `persistence.xml`: namespace Jakarta, versão `3.2`, property keys `jakarta.persistence.jdbc.*`, dialeto `MySQLDialect`
+
+**`F1ManeDados.java`**: `GenerationType.AUTO` → `IDENTITY`
+
+**Docker**: imagem base JRE 11 → JRE 21

--- a/openspec/changes/archive/2026-06-29-java-tomcat-upgrade/specs/java-tomcat-upgrade/spec.md
+++ b/openspec/changes/archive/2026-06-29-java-tomcat-upgrade/specs/java-tomcat-upgrade/spec.md
@@ -1,0 +1,125 @@
+## ADDED Requirements
+
+### Requirement: Projeto compilado com Java 21
+O build do projeto SHALL usar `maven.compiler.release=21` no `pom.xml`.
+
+#### Scenario: Build bem-sucedido com Java 21
+- **WHEN** o desenvolvedor executa `mvn clean package -Ph2 -DskipTests` em ambiente com JDK 21+
+- **THEN** o build conclui sem erros de compilação e o JAR `flmane.jar` é gerado
+
+### Requirement: Tomcat embutido atualizado para 11.x
+O projeto SHALL usar `tomcat-embed-jasper` versão 11.x (Jakarta EE 11 / Servlet 6.1). Esta versão é necessária para compatibilidade com Hibernate 7.4 (Jakarta Persistence 3.2).
+
+#### Scenario: Servidor web sobe com Tomcat 11
+- **WHEN** o JAR é iniciado via `MainLauncher`
+- **THEN** o Tomcat 11 sobe na porta 8080, serve o contexto `/flmane` e registra a versão 11 nos logs de inicialização
+
+#### Scenario: Import javax.servlet no código causa falha de compilação
+- **WHEN** qualquer import `javax.servlet.*` existe no código-fonte
+- **THEN** o build falha em tempo de compilação, não em runtime
+
+### Requirement: Servlet API e JAX-RS migrados para Jakarta EE 11
+O projeto SHALL depender de `jakarta.servlet-api 6.1` e Jersey 4.x. Jersey 4.x é necessário para compatibilidade com Servlet 6.1 (Tomcat 11). Todos os imports `javax.servlet.*`, `javax.ws.rs.*` e `javax.inject.*` SHALL ser substituídos pelos equivalentes `jakarta.*`.
+
+#### Scenario: Nenhum import javax.servlet ou javax.ws.rs no código
+- **WHEN** é executado `grep -r "javax\.servlet\|javax\.ws\.rs" src/main/java`
+- **THEN** nenhum resultado é retornado
+
+#### Scenario: Endpoint REST responde após atualização
+- **WHEN** o servidor está rodando e é feita uma requisição ao endpoint `/letsRace/*`
+- **THEN** a resposta HTTP é recebida com o status esperado pela lógica de negócio
+
+### Requirement: Hibernate atualizado para 7.4
+O projeto SHALL usar `hibernate-core` versão 7.4, que implementa Jakarta Persistence 3.2 (Jakarta EE 11), compatível com Tomcat 11. O artefato `hibernate-entitymanager` SHALL ser removido do `pom.xml`.
+
+#### Scenario: hibernate-entitymanager ausente no pom.xml
+- **WHEN** é verificado o `pom.xml`
+- **THEN** não existe nenhuma dependência com `artifactId` `hibernate-entitymanager`
+
+#### Scenario: Hibernate inicializa com Jakarta Persistence
+- **WHEN** o servidor sobe e a `EntityManagerFactory` é criada por `HibernateUtil`
+- **THEN** a factory é criada sem exceção e as entidades são mapeadas corretamente
+
+### Requirement: Imports javax.persistence migrados para jakarta.persistence
+Todos os imports `javax.persistence.*` SHALL ser substituídos por `jakarta.persistence.*` nos seguintes arquivos: `F1ManeDados.java`, `CampeonatoSrv.java`, `CarreiraDadosSrv.java`, `CorridaCampeonatoSrv.java`, `CorridasDadosSrv.java`, `DadosCorridaCampeonatoSrv.java`, `JogadorDadosSrv.java` e `HibernateUtil.java`.
+
+#### Scenario: Nenhum import javax.persistence no código
+- **WHEN** é executado `grep -r "javax\.persistence" src/main/java`
+- **THEN** nenhum resultado é retornado
+
+### Requirement: API Criteria legada substituída por HQL tipado em ControlePersistencia
+Todos os métodos de `ControlePersistencia.java` que usam `session.createCriteria()`, `org.hibernate.Criteria`, `org.hibernate.criterion.Restrictions`, `org.hibernate.criterion.Order` e `org.hibernate.Query` (legado) SHALL ser reescritos usando `session.createQuery(hql, Tipo.class)` com parâmetros nomeados. Esses tipos foram removidos no Hibernate 6 e não existem mais.
+
+#### Scenario: Nenhum uso de Criteria API legada
+- **WHEN** é executado `grep -r "createCriteria\|org\.hibernate\.Criteria\|criterion\.Restrictions\|criterion\.Order\|import org\.hibernate\.Query" src/main/java`
+- **THEN** nenhum resultado é retornado
+
+#### Scenario: Query por campo único retorna resultado correto
+- **WHEN** é chamado `controlePersistencia.carregaDadosJogador(idUsuario, session)` com um ID existente
+- **THEN** o `JogadorDadosSrv` correspondente é retornado sem exceção
+
+#### Scenario: Query com join retorna resultado correto
+- **WHEN** é chamado `controlePersistencia.carregaCarreiraJogador(idUsuario, false, session)` com ID existente
+- **THEN** o `CarreiraDadosSrv` correspondente é retornado (inclui join com `jogadorDadosSrv`)
+
+#### Scenario: Query com ordenação retorna resultado correto
+- **WHEN** é chamado `controlePersistencia.obterListaCampeonatos(session)`
+- **THEN** a lista é retornada ordenada por `dataCriacao` descendente
+
+### Requirement: saveOrUpdate substituído por merge
+Todas as chamadas `session.saveOrUpdate()` em `ControlePersistencia.java` e `ControleClassificacao.java` SHALL ser substituídas por `session.merge()`. O método `saveOrUpdate` foi removido no Hibernate 6.
+
+#### Scenario: Nenhum uso de saveOrUpdate
+- **WHEN** é executado `grep -r "saveOrUpdate" src/main/java`
+- **THEN** nenhum resultado é retornado
+
+#### Scenario: Novo jogador é persistido via merge
+- **WHEN** é chamado `controlePersistencia.adicionarJogador()` com um novo jogador
+- **THEN** o jogador é salvo no banco e pode ser recuperado na mesma sessão
+
+#### Scenario: Dados existentes são atualizados via merge
+- **WHEN** é chamado `controlePersistencia.gravarDados()` com uma entidade de ID existente
+- **THEN** a entidade é atualizada no banco sem duplicação
+
+### Requirement: persistence.xml migrado para Jakarta Persistence 3.2
+O arquivo `persistence.xml` SHALL usar namespace XML Jakarta (`https://jakarta.ee/xml/ns/persistence`), versão `3.2` e property keys `jakarta.persistence.jdbc.*`.
+
+#### Scenario: persistence.xml com namespace e versão Jakarta Persistence 3.2
+- **WHEN** o arquivo `persistence.xml` é inspecionado
+- **THEN** `xmlns` aponta para `https://jakarta.ee/xml/ns/persistence`, `version` é `3.2` e nenhuma propriedade usa o prefixo `javax.`
+
+### Requirement: Strings javax.persistence em ServletPaddock atualizadas
+As comparações de string hardcoded com `"javax.persistence.jdbc.*"` em `ServletPaddock.java` (linhas ~219–225 no método `getMetaData()`) SHALL ser atualizadas para `"jakarta.persistence.jdbc.*"`.
+
+#### Scenario: Strings de property key atualizadas em ServletPaddock
+- **WHEN** é verificado `ServletPaddock.java`
+- **THEN** não existe nenhuma string literal `"javax.persistence.jdbc"` no arquivo
+
+### Requirement: Dialeto MySQL e hard-codes atualizados para Hibernate 6
+A propriedade `hibernate.dialect` SHALL usar `org.hibernate.dialect.MySQLDialect` em vez de `org.hibernate.dialect.MySQL8Dialect` tanto no `pom.xml` (profile mysql) quanto na string hard-coded em `ServletPaddock.getMetaData()`.
+
+#### Scenario: MySQL8Dialect não referenciado em nenhum lugar
+- **WHEN** é executado `grep -r "MySQL8Dialect" .`
+- **THEN** nenhum resultado é retornado
+
+#### Scenario: Servidor sobe com perfil MySQL sem warning de dialeto
+- **WHEN** o servidor sobe com perfil MySQL
+- **THEN** o Hibernate não loga warning de dialeto depreciado
+
+### Requirement: GenerationType.AUTO substituído por IDENTITY
+O `GenerationType.AUTO` em `F1ManeDados.java` SHALL ser substituído por `GenerationType.IDENTITY`, mapeando explicitamente para `AUTO_INCREMENT` no MySQL e `IDENTITY` no H2, eliminando a ambiguidade de comportamento entre Hibernate 5 e 6.
+
+#### Scenario: Geração de ID funciona em H2
+- **WHEN** uma nova entidade é persistida no banco H2 de desenvolvimento
+- **THEN** o ID é gerado automaticamente sem exceção de sequence ou constraint
+
+#### Scenario: Geração de ID funciona em MySQL
+- **WHEN** uma nova entidade é persistida no banco MySQL
+- **THEN** o ID é gerado via AUTO_INCREMENT sem criação de sequence desnecessária
+
+### Requirement: Imagem Docker base atualizada para JRE 21
+O `Dockerfile` SHALL usar uma imagem JRE/JDK 21.
+
+#### Scenario: Container sobe com JRE 21
+- **WHEN** o Docker Compose é iniciado
+- **THEN** o container `flmane` sobe sem erro de versão de JVM e serve a aplicação normalmente

--- a/openspec/changes/archive/2026-06-29-java-tomcat-upgrade/specs/sdd-execution-modes/spec.md
+++ b/openspec/changes/archive/2026-06-29-java-tomcat-upgrade/specs/sdd-execution-modes/spec.md
@@ -1,0 +1,16 @@
+## MODIFIED Requirements
+
+### Requirement: MainLauncher descrito
+O SDD SHALL descrever que `MainLauncher` sobe **Tomcat 11** na porta 8080, extrai `webapp/` do JAR para um diretório temporário `flmane-webapp`, mapeia contexto em `/flmane`, e exibe launcher Swing com QR Code (exceto quando `--headless`). O Tomcat 11 usa **Jakarta EE 11** (`jakarta.*` namespace) — a dependência `javax.servlet-api` foi substituída por `jakarta.servlet-api 6.1`.
+
+#### Scenario: Entry points descritos
+- **WHEN** o leitor consulta a seção de modos de execução
+- **THEN** encontra os três entry points: `MainLauncher`, `MainFrame` e `AppletPaddock`, com a classe Java correspondente a cada um
+
+#### Scenario: MainLauncher descrito com Tomcat 11
+- **WHEN** o leitor consulta o modo web
+- **THEN** o SDD descreve que `MainLauncher` sobe **Tomcat 11** na porta 8080, usando Jakarta Servlet 6.1
+
+#### Scenario: Namespace jakarta documentado no modo servidor
+- **WHEN** o leitor consulta detalhes de dependências do modo servidor
+- **THEN** o SDD indica que o projeto usa `jakarta.servlet.*`, `jakarta.ws.rs.*` (Jersey 4.x) e `jakarta.persistence.*` (Hibernate 7.4 / Jakarta Persistence 3.2), sem nenhuma referência ao namespace legado `javax.*`

--- a/openspec/changes/archive/2026-06-29-java-tomcat-upgrade/tasks.md
+++ b/openspec/changes/archive/2026-06-29-java-tomcat-upgrade/tasks.md
@@ -1,0 +1,94 @@
+## 1. Atualizar pom.xml
+
+- [x] 1.1 Alterar `maven.compiler.release` de `11` para `21`
+- [x] 1.2 Atualizar `tomcat-embed-jasper` para a versão 11.x mais recente estável
+- [x] 1.3 Remover `javax.servlet-api`; adicionar `jakarta.servlet-api:6.1`
+- [x] 1.4 Atualizar `jersey-server`, `jersey-container-servlet`, `jersey-hk2` e `jersey-media-json-jackson` para versão 4.0.2 (artefato renomeado de `jersey-container-servlet-core` → `jersey-container-servlet`)
+- [x] 1.5 Atualizar `hibernate-core` de `5.6.15.Final` para `7.4.0.Final` com novo groupId `org.hibernate.orm`
+- [x] 1.6 Remover a dependência `hibernate-entitymanager` do `pom.xml`
+- [x] 1.7 Atualizar dialeto MySQL no profile `mysql`: `MySQL8Dialect` → `MySQLDialect`
+- [x] 1.8 Verificar que não restam transitivas javax legados (build passou com -U)
+
+## 2. Migrar imports javax.servlet e javax.ws.rs (servlet / JAX-RS)
+
+- [x] 2.1 Migrar imports em `LetsRace.java`: `javax.ws.rs.*` → `jakarta.ws.rs.*`
+- [x] 2.2 Migrar imports em `ServletPaddock.java`: `javax.servlet.*` → `jakarta.servlet.*`
+- [x] 2.3 Atualizar strings hardcoded em `ServletPaddock.java` (método `getMetaData()`, ~linhas 219–225): `"javax.persistence.jdbc.*"` → `"jakarta.persistence.jdbc.*"`
+- [x] 2.4 Atualizar string hardcoded `"org.hibernate.dialect.MySQL8Dialect"` em `ServletPaddock.getMetaData()` para `"org.hibernate.dialect.MySQLDialect"`
+- [x] 2.5 Migrar imports em `Compress.java`: `javax.servlet.*` → `jakarta.servlet.*`
+- [x] 2.6 Migrar imports em `GZIPWriterInterceptor.java`: `javax.ws.rs.*` → `jakarta.ws.rs.*`
+
+## 3. Migrar imports javax.persistence (entidades JPA e HibernateUtil)
+
+- [x] 3.1 Migrar imports em `HibernateUtil.java`: `javax.persistence.*` → `jakarta.persistence.*`
+- [x] 3.2 Migrar imports em `F1ManeDados.java`: `javax.persistence.*` → `jakarta.persistence.*`
+- [x] 3.3 Migrar imports em `CampeonatoSrv.java`: `javax.persistence.*` → `jakarta.persistence.*`
+- [x] 3.4 Migrar imports em `CarreiraDadosSrv.java`: `javax.persistence.*` → `jakarta.persistence.*`
+- [x] 3.5 Migrar imports em `CorridaCampeonatoSrv.java`: `javax.persistence.*` → `jakarta.persistence.*`
+- [x] 3.6 Migrar imports em `CorridasDadosSrv.java`: `javax.persistence.*` → `jakarta.persistence.*`
+- [x] 3.7 Migrar imports em `DadosCorridaCampeonatoSrv.java`: `javax.persistence.*` → `jakarta.persistence.*`
+- [x] 3.8 Migrar imports em `JogadorDadosSrv.java`: `javax.persistence.*` → `jakarta.persistence.*`
+- [x] 3.9 Verificado com `grep -r "javax\." src/main/java` — nenhum resultado (Jakarta EE)
+
+## 4. Atualizar persistence.xml
+
+- [x] 4.1 Trocar `xmlns="http://xmlns.jcp.org/xml/ns/persistence"` por `xmlns="https://jakarta.ee/xml/ns/persistence"`
+- [x] 4.2 Atualizar `version="2.2"` para `version="3.2"`
+- [x] 4.3 Renomear property keys `javax.persistence.jdbc.*` para `jakarta.persistence.jdbc.*` nos dois perfis (h2 e mysql)
+- [x] 4.4 Trocar `GenerationType.AUTO` por `GenerationType.IDENTITY` em `F1ManeDados.java`
+
+## 5. Reescrever ControlePersistencia.java — queries Criteria → HQL
+
+- [x] 5.1 Reescrever `carregaDadosJogador()` — `createCriteria` + `Restrictions.eq("idUsuario")` → HQL
+- [x] 5.2 Reescrever `carregaDadosJogadorNome()` — `createCriteria` + `Restrictions.eq("nome")` → HQL
+- [x] 5.3 Reescrever `carregaDadosJogadorIdUsuario()` — `createCriteria` + `Restrictions.eq("idUsuario")` → HQL
+- [x] 5.4 Reescrever `carregaDadosJogadorId()` — `createCriteria` + `Restrictions.eq("id")` → HQL
+- [x] 5.5 Reescrever `carregaDadosJogadorEmail()` — `createCriteria` + `Restrictions.eq("email")` → HQL
+- [x] 5.6 Reescrever `obterListaJogadores()` — `createCriteria(JogadorDadosSrv.class)` sem filtro → HQL `"from JogadorDadosSrv"`
+- [x] 5.7 Reescrever `obterListaJogadoresCorridasPeriodo()` — `createCriteria` + `Restrictions.ge/le` → HQL com >= e <=
+- [x] 5.8 Reescrever `obterListaCorridas()` — `createCriteria` + `createAlias("jogadorDadosSrv","j")` + `Order.asc` → HQL com JOIN e ORDER BY
+- [x] 5.9 Reescrever `obterClassificacaoCircuito()` — `createCriteria` + `Restrictions.eq/gt` → HQL
+- [x] 5.10 Reescrever `obterClassificacaoTemporada()` — `createCriteria` + `Restrictions.eq/gt` → HQL
+- [x] 5.11 Reescrever `carregaCarreiraJogador()` — `createCriteria` + `createAlias` + `Restrictions.eq("j.idUsuario")` → HQL com JOIN
+- [x] 5.12 Reescrever `obterListaCampeonatos()` — `createCriteria` + `Order.desc("dataCriacao")` → HQL com ORDER BY
+- [x] 5.13 Reescrever `pesquisaCampeonato()` — `createCriteria` + `Restrictions.eq("id")` → HQL
+- [x] 5.14 Reescrever `pesquisaCampeonatos(idUsuario)` — `createCriteria` + `createAlias` + eq → HQL com JOIN
+- [x] 5.15 Reescrever `pesquisaCampeonatosEmAberto()` — `createCriteria` + `createAlias` + `eq(Boolean.FALSE)` → HQL com JOIN e WHERE finalizado = false
+- [x] 5.16 Reescrever `pesquisaCampeonatoId()` — `createCriteria` + `uniqueResult()` → HQL com `.uniqueResultOptional().orElse(null)`
+- [x] 5.17 Reescrever `pesquisaCampeonatos(jogadorDadosSrv)` — `createCriteria` + `Restrictions.eq(objeto)` → HQL
+- [x] 5.18 Reescrever `existeNomeCarro()` — `createCriteria` + `createAlias` + `Restrictions.ne` → HQL com JOIN e `<>`
+- [x] 5.19 Reescrever `existeNomePiloto()` — `createCriteria` + `createAlias` + `Restrictions.ne` → HQL
+- [x] 5.20 Reescrever `existeNomeCampeonato()` — `createCriteria` + `Restrictions.eq("nome")` → HQL
+- [x] 5.21 Reescrever `obterClassificacaoGeral()` — `createCriteria` + `Restrictions.gt("pontos")` → HQL
+- [x] 5.22 Reescrever `obterClassificacaoEquipes()` — `createCriteria` + `isNotNull` + `gt` + `Order.desc` → HQL com WHERE e ORDER BY
+- [x] 5.23 Reescrever `obterClassificacaoCampeonato()` — `org.hibernate.Query` legado → `session.createQuery(hql, CampeonatoSrv.class)` tipado
+- [x] 5.24 Substituir `session.saveOrUpdate()` por `session.merge()` em `adicionarJogador()` e `gravarDados()`
+- [x] 5.25 Remover imports removidos: `org.hibernate.Criteria`, `org.hibernate.Query`, `org.hibernate.criterion.Restrictions`, `org.hibernate.criterion.Order`
+
+## 6. Reescrever ControleClassificacao.java — Criteria e saveOrUpdate
+
+- [x] 6.1 Reescrever `obterListaClassificacao()`: `session.createCriteria(CorridasDadosSrv.class)` + Restrictions → HQL
+- [x] 6.2 Substituir 3 chamadas `session.saveOrUpdate()` em `processaCorrida()` por `session.merge()`
+- [x] 6.3 Remover imports `org.hibernate.criterion.Restrictions` do arquivo
+
+## 7. Verificar ServletPaddock.createSchema (SchemaExport)
+
+- [x] 7.1 `SchemaExport` removido do `hibernate-core` no Hibernate 6+. Substituído por `Persistence.generateSchema("flmane-jpa", props)` (JPA padrão). Métodos auxiliares `getMetaData()` e inner class `MyConnectionProvider` removidos.
+
+## 8. Atualizar Dockerfile
+
+- [x] 8.1 Dockerfile já usa `eclipse-temurin:21-jre-alpine` — nenhuma alteração necessária
+- [x] 8.2 Imagem base já está em JRE 21
+
+## 9. Validar build e execução
+
+- [x] 9.1 `mvn clean package -Ph2 -DskipTests` — BUILD SUCCESS
+- [x] 9.2 `grep -r "javax\." src/main/java` — nenhuma ocorrência Jakarta EE restante
+- [x] 9.3 `grep -r "createCriteria\|saveOrUpdate\|org\.hibernate\.Query" src/main/java` — nenhum resultado
+- [x] 9.4 Subir o servidor com `java -jar target/flmane.jar` e confirmar que Tomcat 11 e Hibernate 7 inicializam sem erros
+- [x] 9.5 Testar um fluxo que persiste dados (ex: criação de jogador) e confirmar que `merge()` salva corretamente
+- [x] 9.6 Testar uma query com join (ex: busca de carreira por idUsuario) e confirmar retorno correto
+- [ ] 9.7 Executar `./simulacao.sh` e confirmar que simulação headless conclui sem exceções
+- [ ] 9.8 Testar acesso à página web em `http://localhost:8080/flmane/html5/index.html`
+- [ ] 9.9 Subir via Docker Compose (`docker compose up --build`) e confirmar container com JRE 21
+- [ ] 9.10 Confirmar que IDs são gerados corretamente com `IDENTITY` tanto em H2 quanto em MySQL

--- a/openspec/specs/java-tomcat-upgrade/spec.md
+++ b/openspec/specs/java-tomcat-upgrade/spec.md
@@ -1,0 +1,125 @@
+## ADDED Requirements
+
+### Requirement: Projeto compilado com Java 21
+O build do projeto SHALL usar `maven.compiler.release=21` no `pom.xml`.
+
+#### Scenario: Build bem-sucedido com Java 21
+- **WHEN** o desenvolvedor executa `mvn clean package -Ph2 -DskipTests` em ambiente com JDK 21+
+- **THEN** o build conclui sem erros de compilação e o JAR `flmane.jar` é gerado
+
+### Requirement: Tomcat embutido atualizado para 11.x
+O projeto SHALL usar `tomcat-embed-jasper` versão 11.x (Jakarta EE 11 / Servlet 6.1). Esta versão é necessária para compatibilidade com Hibernate 7.4 (Jakarta Persistence 3.2).
+
+#### Scenario: Servidor web sobe com Tomcat 11
+- **WHEN** o JAR é iniciado via `MainLauncher`
+- **THEN** o Tomcat 11 sobe na porta 8080, serve o contexto `/flmane` e registra a versão 11 nos logs de inicialização
+
+#### Scenario: Import javax.servlet no código causa falha de compilação
+- **WHEN** qualquer import `javax.servlet.*` existe no código-fonte
+- **THEN** o build falha em tempo de compilação, não em runtime
+
+### Requirement: Servlet API e JAX-RS migrados para Jakarta EE 11
+O projeto SHALL depender de `jakarta.servlet-api 6.1` e Jersey 4.x. Jersey 4.x é necessário para compatibilidade com Servlet 6.1 (Tomcat 11). Todos os imports `javax.servlet.*`, `javax.ws.rs.*` e `javax.inject.*` SHALL ser substituídos pelos equivalentes `jakarta.*`.
+
+#### Scenario: Nenhum import javax.servlet ou javax.ws.rs no código
+- **WHEN** é executado `grep -r "javax\.servlet\|javax\.ws\.rs" src/main/java`
+- **THEN** nenhum resultado é retornado
+
+#### Scenario: Endpoint REST responde após atualização
+- **WHEN** o servidor está rodando e é feita uma requisição ao endpoint `/letsRace/*`
+- **THEN** a resposta HTTP é recebida com o status esperado pela lógica de negócio
+
+### Requirement: Hibernate atualizado para 7.4
+O projeto SHALL usar `hibernate-core` versão 7.4, que implementa Jakarta Persistence 3.2 (Jakarta EE 11), compatível com Tomcat 11. O artefato `hibernate-entitymanager` SHALL ser removido do `pom.xml`.
+
+#### Scenario: hibernate-entitymanager ausente no pom.xml
+- **WHEN** é verificado o `pom.xml`
+- **THEN** não existe nenhuma dependência com `artifactId` `hibernate-entitymanager`
+
+#### Scenario: Hibernate inicializa com Jakarta Persistence
+- **WHEN** o servidor sobe e a `EntityManagerFactory` é criada por `HibernateUtil`
+- **THEN** a factory é criada sem exceção e as entidades são mapeadas corretamente
+
+### Requirement: Imports javax.persistence migrados para jakarta.persistence
+Todos os imports `javax.persistence.*` SHALL ser substituídos por `jakarta.persistence.*` nos seguintes arquivos: `F1ManeDados.java`, `CampeonatoSrv.java`, `CarreiraDadosSrv.java`, `CorridaCampeonatoSrv.java`, `CorridasDadosSrv.java`, `DadosCorridaCampeonatoSrv.java`, `JogadorDadosSrv.java` e `HibernateUtil.java`.
+
+#### Scenario: Nenhum import javax.persistence no código
+- **WHEN** é executado `grep -r "javax\.persistence" src/main/java`
+- **THEN** nenhum resultado é retornado
+
+### Requirement: API Criteria legada substituída por HQL tipado em ControlePersistencia
+Todos os métodos de `ControlePersistencia.java` que usam `session.createCriteria()`, `org.hibernate.Criteria`, `org.hibernate.criterion.Restrictions`, `org.hibernate.criterion.Order` e `org.hibernate.Query` (legado) SHALL ser reescritos usando `session.createQuery(hql, Tipo.class)` com parâmetros nomeados. Esses tipos foram removidos no Hibernate 6 e não existem mais.
+
+#### Scenario: Nenhum uso de Criteria API legada
+- **WHEN** é executado `grep -r "createCriteria\|org\.hibernate\.Criteria\|criterion\.Restrictions\|criterion\.Order\|import org\.hibernate\.Query" src/main/java`
+- **THEN** nenhum resultado é retornado
+
+#### Scenario: Query por campo único retorna resultado correto
+- **WHEN** é chamado `controlePersistencia.carregaDadosJogador(idUsuario, session)` com um ID existente
+- **THEN** o `JogadorDadosSrv` correspondente é retornado sem exceção
+
+#### Scenario: Query com join retorna resultado correto
+- **WHEN** é chamado `controlePersistencia.carregaCarreiraJogador(idUsuario, false, session)` com ID existente
+- **THEN** o `CarreiraDadosSrv` correspondente é retornado (inclui join com `jogadorDadosSrv`)
+
+#### Scenario: Query com ordenação retorna resultado correto
+- **WHEN** é chamado `controlePersistencia.obterListaCampeonatos(session)`
+- **THEN** a lista é retornada ordenada por `dataCriacao` descendente
+
+### Requirement: saveOrUpdate substituído por merge
+Todas as chamadas `session.saveOrUpdate()` em `ControlePersistencia.java` e `ControleClassificacao.java` SHALL ser substituídas por `session.merge()`. O método `saveOrUpdate` foi removido no Hibernate 6.
+
+#### Scenario: Nenhum uso de saveOrUpdate
+- **WHEN** é executado `grep -r "saveOrUpdate" src/main/java`
+- **THEN** nenhum resultado é retornado
+
+#### Scenario: Novo jogador é persistido via merge
+- **WHEN** é chamado `controlePersistencia.adicionarJogador()` com um novo jogador
+- **THEN** o jogador é salvo no banco e pode ser recuperado na mesma sessão
+
+#### Scenario: Dados existentes são atualizados via merge
+- **WHEN** é chamado `controlePersistencia.gravarDados()` com uma entidade de ID existente
+- **THEN** a entidade é atualizada no banco sem duplicação
+
+### Requirement: persistence.xml migrado para Jakarta Persistence 3.2
+O arquivo `persistence.xml` SHALL usar namespace XML Jakarta (`https://jakarta.ee/xml/ns/persistence`), versão `3.2` e property keys `jakarta.persistence.jdbc.*`.
+
+#### Scenario: persistence.xml com namespace e versão Jakarta Persistence 3.2
+- **WHEN** o arquivo `persistence.xml` é inspecionado
+- **THEN** `xmlns` aponta para `https://jakarta.ee/xml/ns/persistence`, `version` é `3.2` e nenhuma propriedade usa o prefixo `javax.`
+
+### Requirement: Strings javax.persistence em ServletPaddock atualizadas
+As comparações de string hardcoded com `"javax.persistence.jdbc.*"` em `ServletPaddock.java` (linhas ~219–225 no método `getMetaData()`) SHALL ser atualizadas para `"jakarta.persistence.jdbc.*"`.
+
+#### Scenario: Strings de property key atualizadas em ServletPaddock
+- **WHEN** é verificado `ServletPaddock.java`
+- **THEN** não existe nenhuma string literal `"javax.persistence.jdbc"` no arquivo
+
+### Requirement: Dialeto MySQL e hard-codes atualizados para Hibernate 6
+A propriedade `hibernate.dialect` SHALL usar `org.hibernate.dialect.MySQLDialect` em vez de `org.hibernate.dialect.MySQL8Dialect` tanto no `pom.xml` (profile mysql) quanto na string hard-coded em `ServletPaddock.getMetaData()`.
+
+#### Scenario: MySQL8Dialect não referenciado em nenhum lugar
+- **WHEN** é executado `grep -r "MySQL8Dialect" .`
+- **THEN** nenhum resultado é retornado
+
+#### Scenario: Servidor sobe com perfil MySQL sem warning de dialeto
+- **WHEN** o servidor sobe com perfil MySQL
+- **THEN** o Hibernate não loga warning de dialeto depreciado
+
+### Requirement: GenerationType.AUTO substituído por IDENTITY
+O `GenerationType.AUTO` em `F1ManeDados.java` SHALL ser substituído por `GenerationType.IDENTITY`, mapeando explicitamente para `AUTO_INCREMENT` no MySQL e `IDENTITY` no H2, eliminando a ambiguidade de comportamento entre Hibernate 5 e 6.
+
+#### Scenario: Geração de ID funciona em H2
+- **WHEN** uma nova entidade é persistida no banco H2 de desenvolvimento
+- **THEN** o ID é gerado automaticamente sem exceção de sequence ou constraint
+
+#### Scenario: Geração de ID funciona em MySQL
+- **WHEN** uma nova entidade é persistida no banco MySQL
+- **THEN** o ID é gerado via AUTO_INCREMENT sem criação de sequence desnecessária
+
+### Requirement: Imagem Docker base atualizada para JRE 21
+O `Dockerfile` SHALL usar uma imagem JRE/JDK 21.
+
+#### Scenario: Container sobe com JRE 21
+- **WHEN** o Docker Compose é iniciado
+- **THEN** o container `flmane` sobe sem erro de versão de JVM e serve a aplicação normalmente

--- a/openspec/specs/sdd-execution-modes/spec.md
+++ b/openspec/specs/sdd-execution-modes/spec.md
@@ -12,9 +12,16 @@ O SDD SHALL descrever os três modos de execução do JAR `flmane.jar`, seus ent
 - **WHEN** o leitor consulta a seção de modos de execução
 - **THEN** encontra os três entry points: `MainLauncher`, `MainFrame` e `AppletPaddock`, com a classe Java correspondente a cada um
 
-#### Scenario: MainLauncher descrito
+### Requirement: MainLauncher descrito
+O SDD SHALL descrever que `MainLauncher` sobe **Tomcat 11** na porta 8080, extrai `webapp/` do JAR para um diretório temporário `flmane-webapp`, mapeia contexto em `/flmane`, e exibe launcher Swing com QR Code (exceto quando `--headless`). O Tomcat 11 usa **Jakarta EE 11** (`jakarta.*` namespace) — a dependência `javax.servlet-api` foi substituída por `jakarta.servlet-api 6.1`.
+
+#### Scenario: MainLauncher descrito com Tomcat 11
 - **WHEN** o leitor consulta o modo web
-- **THEN** o SDD descreve que `MainLauncher` sobe Tomcat na porta 8080, extrai `webapp/` do JAR para um diretório temporário `flmane-webapp`, mapeia contexto em `/flmane`, e exibe launcher Swing com QR Code (exceto quando `--headless`)
+- **THEN** o SDD descreve que `MainLauncher` sobe **Tomcat 11** na porta 8080, usando Jakarta Servlet 6.1
+
+#### Scenario: Namespace jakarta documentado no modo servidor
+- **WHEN** o leitor consulta detalhes de dependências do modo servidor
+- **THEN** o SDD indica que o projeto usa `jakarta.servlet.*`, `jakarta.ws.rs.*` (Jersey 4.x) e `jakarta.persistence.*` (Hibernate 7.4 / Jakarta Persistence 3.2), sem nenhuma referência ao namespace legado `javax.*`
 
 #### Scenario: MainFrame descrito
 - **WHEN** o leitor consulta o modo solo

--- a/pom.xml
+++ b/pom.xml
@@ -19,24 +19,15 @@
             <version>1.11.0</version>
         </dependency>
         <dependency>
-            <groupId>org.hibernate</groupId>
+            <groupId>org.hibernate.orm</groupId>
             <artifactId>hibernate-core</artifactId>
-            <version>5.6.15.Final</version>
+            <version>7.4.0.Final</version>
         </dependency>
         <dependency>
-            <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-entitymanager</artifactId>
-            <version>5.6.15.Final</version>
-        </dependency>
-        <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
-            <version>2.1.1</version>
-        </dependency>
-        <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>4.0.1</version>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <version>6.1.0</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.mysql</groupId>
@@ -46,22 +37,22 @@
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-server</artifactId>
-            <version>2.41</version>
+            <version>4.0.2</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.containers</groupId>
-            <artifactId>jersey-container-servlet-core</artifactId>
-            <version>2.41</version>
+            <artifactId>jersey-container-servlet</artifactId>
+            <version>4.0.2</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.inject</groupId>
             <artifactId>jersey-hk2</artifactId>
-            <version>2.41</version>
+            <version>4.0.2</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>
             <artifactId>jersey-media-json-jackson</artifactId>
-            <version>2.41</version>
+            <version>4.0.2</version>
         </dependency>
         <dependency>
             <groupId>commons-lang</groupId>
@@ -71,7 +62,7 @@
         <dependency>
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-jasper</artifactId>
-            <version>9.0.89</version>
+            <version>11.0.3</version>
         </dependency>
         <dependency>
             <groupId>com.h2database</groupId>
@@ -208,7 +199,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.11.0</version>
                 <configuration>
-                    <release>11</release>
+                    <release>21</release>
                 </configuration>
             </plugin>
             <plugin>
@@ -225,10 +216,11 @@
                             <createDependencyReducedPom>false</createDependencyReducedPom>
                             <artifactSet>
                                 <excludes>
-                                    <!-- duplicados: substituídos pelas versões jakarta/tomcat incluídas -->
+                                    <!-- excluir artefatos javax legados caso venham como transitivas -->
                                     <exclude>javax.servlet:javax.servlet-api</exclude>
                                     <exclude>javax.ws.rs:javax.ws.rs-api</exclude>
                                     <exclude>javax.xml.bind:jaxb-api</exclude>
+                                    <exclude>javax.persistence:javax.persistence-api</exclude>
                                     <exclude>jakarta.annotation:jakarta.annotation-api</exclude>
                                 </excludes>
                             </artifactSet>
@@ -250,6 +242,8 @@
                                         <exclude>META-INF/NOTICE.markdown</exclude>
                                         <exclude>META-INF/MANIFEST.MF</exclude>
                                         <exclude>META-INF/web-fragment.xml</exclude>
+                                        <exclude>about.html</exclude>
+                                        <exclude>LICENSE</exclude>
                                     </excludes>
                                 </filter>
                             </filters>
@@ -268,7 +262,7 @@
         </plugins>
     </build>
     <properties>
-        <maven.compiler.release>11</maven.compiler.release>
+        <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <env>h2</env>
     </properties>
@@ -310,7 +304,7 @@
                     flmane
                 </jdbc.password>
                 <hibernate.dialect>
-                    org.hibernate.dialect.MySQL8Dialect
+                    org.hibernate.dialect.MySQLDialect
                 </hibernate.dialect>
             </properties>
         </profile>

--- a/src/main/java/br/f1mane/editor/TestePista.java
+++ b/src/main/java/br/f1mane/editor/TestePista.java
@@ -147,12 +147,7 @@ public class TestePista {
 
 	}
 
-	protected void finalize() throws Throwable {
-		alive = false;
-		super.finalize();
-	}
-
-	public void testarBox() {
+public void testarBox() {
 		irProBox = !irProBox;
 	}
 

--- a/src/main/java/br/f1mane/servidor/controles/ControleCampeonatoServidor.java
+++ b/src/main/java/br/f1mane/servidor/controles/ControleCampeonatoServidor.java
@@ -104,6 +104,9 @@ public class ControleCampeonatoServidor {
 
             }
             campeonato.setFinalizado(false);
+            if (campeonato.getNivel() == null) {
+                campeonato.setNivel(Global.CONTROLE_AUTOMATICO);
+            }
             controlePersistencia.gravarDados(session, campeonato);
             return (new MsgSrv(Lang.msg("campeonatoCriado")));
         } catch (Exception e) {
@@ -613,11 +616,11 @@ public class ControleCampeonatoServidor {
                 new DadosClassificacaoJogadorComparator());
     }
 
-    public Object finalizaCampeonato(CampeonatoTO campeonato, String token) {
+    public Object finalizaCampeonato(CampeonatoTO campeonato, String idUsuario) {
         Session session = controlePersistencia.getSession();
         try {
             List pesquisaCampeonatosEmAberto = controlePersistencia
-                    .pesquisaCampeonatosEmAberto(token, session, false);
+                    .pesquisaCampeonatosEmAberto(idUsuario, session, false);
             if (pesquisaCampeonatosEmAberto.isEmpty()) {
                 return null;
             }

--- a/src/main/java/br/f1mane/servidor/controles/ControleClassificacao.java
+++ b/src/main/java/br/f1mane/servidor/controles/ControleClassificacao.java
@@ -11,7 +11,6 @@ import br.f1mane.servidor.entidades.persistencia.JogadorDadosSrv;
 import br.nnpe.*;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
-import org.hibernate.criterion.Restrictions;
 
 import java.util.*;
 
@@ -43,10 +42,12 @@ public class ControleClassificacao {
             for (Iterator iter = jogadores.iterator(); iter.hasNext(); ) {
                 String key = (String) iter.next();
                 JogadorDadosSrv jogadorDadosSrv = controlePersistencia.carregaDadosJogador(key, session);
-                List corridas = session.createCriteria(CorridasDadosSrv.class)
-                        .add(Restrictions.eq("jogadorDadosSrv", jogadorDadosSrv))
-                        .add(Restrictions.ge("tempoFim", Long.valueOf(ini.toTimestamp().getTime())))
-                        .add(Restrictions.le("tempoFim", Long.valueOf(fim.toTimestamp().getTime()))).list();
+                List<CorridasDadosSrv> corridas = session.createQuery(
+                        "from CorridasDadosSrv where jogadorDadosSrv = :jogador " +
+                        "and tempoFim >= :ini and tempoFim <= :fim", CorridasDadosSrv.class)
+                        .setParameter("jogador", jogadorDadosSrv)
+                        .setParameter("ini", ini.toTimestamp().getTime())
+                        .setParameter("fim", fim.toTimestamp().getTime()).list();
                 DadosJogador dadosJogador = new DadosJogador();
                 dadosJogador.setNome(jogadorDadosSrv.getNome());
                 dadosJogador.setUltimoAceso(jogadorDadosSrv.getUltimoLogon());
@@ -117,10 +118,8 @@ public class ControleClassificacao {
                     JogadorDadosSrv idJog = new JogadorDadosSrv();
                     idJog.setId(jogadorDadosSrv.getId());
                     corridasDadosSrv.setJogadorDadosSrv(idJog);
-                    jogadorDadosSrv.getCorridas().add(corridasDadosSrv);
-                    session.saveOrUpdate(corridasDadosSrv);
-                    session.saveOrUpdate(carreiraDadosSrv);
-                    session.saveOrUpdate(jogadorDadosSrv);
+                    session.merge(corridasDadosSrv);
+                    session.merge(carreiraDadosSrv);
                 }
             }
             transaction.commit();
@@ -334,11 +333,11 @@ public class ControleClassificacao {
                 if (i > 2) {
                     break;
                 }
-                Character character = new Character(carreiraDados.getNomePilotoAbreviado().charAt(i));
+                char c = carreiraDados.getNomePilotoAbreviado().charAt(i);
                 if (i == 0) {
-                    nmAbrv.append(character.toString().toUpperCase());
+                    nmAbrv.append(String.valueOf(c).toUpperCase());
                 } else {
-                    nmAbrv.append(character.toString().toLowerCase());
+                    nmAbrv.append(String.valueOf(c).toLowerCase());
                 }
 
             }

--- a/src/main/java/br/f1mane/servidor/controles/ControlePaddockServidor.java
+++ b/src/main/java/br/f1mane/servidor/controles/ControlePaddockServidor.java
@@ -909,8 +909,8 @@ public class ControlePaddockServidor {
         }
     }
 
-    public Object finalizaCampeonato(CampeonatoTO campeonato, String token) {
-        return controleCampeonatoServidor.finalizaCampeonato(campeonato, token);
+    public Object finalizaCampeonato(CampeonatoTO campeonato, String idUsuario) {
+        return controleCampeonatoServidor.finalizaCampeonato(campeonato, idUsuario);
     }
 
     public Object jogar(String temporada, String circuito, String idPiloto, String numVoltas, String tipoPneu,

--- a/src/main/java/br/f1mane/servidor/controles/ControlePersistencia.java
+++ b/src/main/java/br/f1mane/servidor/controles/ControlePersistencia.java
@@ -10,17 +10,13 @@ import br.nnpe.Global;
 import br.nnpe.Dia;
 import br.nnpe.Logger;
 import br.nnpe.Util;
-import org.hibernate.Criteria;
-import org.hibernate.Query;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
-import org.hibernate.criterion.Order;
-import org.hibernate.criterion.Restrictions;
 
 import java.util.*;
 
 /**
- * @author Paulo Sobreira Criado em 20/10/2007 as 14:19:54
+ * @author Paulo Sobreira Criada em 20/10/2007 as 14:19:54
  */
 public class ControlePersistencia {
 
@@ -48,7 +44,6 @@ public class ControlePersistencia {
                 Logger.logar("heapSize " + Runtime.getRuntime().totalMemory() / 1024 + " kb");
                 Logger.logar("heapMaxSize " + Runtime.getRuntime().maxMemory() / 1024 + " kb");
                 Logger.logar("heapFreeSize " + Runtime.getRuntime().freeMemory() / 1024 + " kb");
-                // paddockDadosSrv = lerDados();
                 Logger.logar("============ Depois==========================");
                 Logger.logar("heapSize " + Runtime.getRuntime().totalMemory() / 1024 + " kb");
                 Logger.logar("heapMaxSize " + Runtime.getRuntime().maxMemory() / 1024 + " kb");
@@ -85,47 +80,52 @@ public class ControlePersistencia {
     }
 
     public JogadorDadosSrv carregaDadosJogador(String idUsuario, Session session) {
-        List jogador = session.createCriteria(JogadorDadosSrv.class).add(Restrictions.eq("idUsuario", idUsuario)).list();
-        JogadorDadosSrv jogadorDadosSrv = (JogadorDadosSrv) (jogador.isEmpty() ? null : jogador.get(0));
-        return jogadorDadosSrv;
+        List<JogadorDadosSrv> jogador = session.createQuery(
+                "from JogadorDadosSrv where idUsuario = :idUsuario", JogadorDadosSrv.class)
+                .setParameter("idUsuario", idUsuario).list();
+        return jogador.isEmpty() ? null : jogador.get(0);
     }
 
     public JogadorDadosSrv carregaDadosJogadorNome(String nomeJogador, Session session) {
-        List jogador = session.createCriteria(JogadorDadosSrv.class).add(Restrictions.eq("nome", nomeJogador)).list();
-        JogadorDadosSrv jogadorDadosSrv = (JogadorDadosSrv) (jogador.isEmpty() ? null : jogador.get(0));
-        return jogadorDadosSrv;
+        List<JogadorDadosSrv> jogador = session.createQuery(
+                "from JogadorDadosSrv where nome = :nome", JogadorDadosSrv.class)
+                .setParameter("nome", nomeJogador).list();
+        return jogador.isEmpty() ? null : jogador.get(0);
     }
 
     public JogadorDadosSrv carregaDadosJogadorIdUsuario(String idUsuario, Session session) {
-        List jogador = session.createCriteria(JogadorDadosSrv.class).add(Restrictions.eq("idUsuario", idUsuario)).list();
-        JogadorDadosSrv jogadorDadosSrv = (JogadorDadosSrv) (jogador.isEmpty() ? null : jogador.get(0));
-        return jogadorDadosSrv;
+        List<JogadorDadosSrv> jogador = session.createQuery(
+                "from JogadorDadosSrv where idUsuario = :idUsuario", JogadorDadosSrv.class)
+                .setParameter("idUsuario", idUsuario).list();
+        return jogador.isEmpty() ? null : jogador.get(0);
     }
 
     public JogadorDadosSrv carregaDadosJogadorId(Long id, Session session) {
-        List jogador = session.createCriteria(JogadorDadosSrv.class).add(Restrictions.eq("id", id)).list();
-        JogadorDadosSrv jogadorDadosSrv = (JogadorDadosSrv) (jogador.isEmpty() ? null : jogador.get(0));
-        return jogadorDadosSrv;
+        List<JogadorDadosSrv> jogador = session.createQuery(
+                "from JogadorDadosSrv where id = :id", JogadorDadosSrv.class)
+                .setParameter("id", id).list();
+        return jogador.isEmpty() ? null : jogador.get(0);
     }
 
     public Set obterListaJogadores(Session session) {
         Set nomes = new HashSet();
-        List jogador = session.createCriteria(JogadorDadosSrv.class).list();
-        for (Iterator iterator = jogador.iterator(); iterator.hasNext(); ) {
-            JogadorDadosSrv jogadorDadosSrv = (JogadorDadosSrv) iterator.next();
-            nomes.add(jogadorDadosSrv.getIdUsuario());
+        List<JogadorDadosSrv> jogadores = session.createQuery(
+                "from JogadorDadosSrv", JogadorDadosSrv.class).list();
+        for (JogadorDadosSrv j : jogadores) {
+            nomes.add(j.getIdUsuario());
         }
         return nomes;
     }
 
     public Set obterListaJogadoresCorridasPeriodo(Session session, Dia ini, Dia fim) {
         Set nomes = new HashSet();
-        List corridas = session.createCriteria(CorridasDadosSrv.class)
-                .add(Restrictions.ge("tempoFim", Long.valueOf(ini.toTimestamp().getTime())))
-                .add(Restrictions.le("tempoFim", Long.valueOf(fim.toTimestamp().getTime()))).list();
-        for (Iterator iterator = corridas.iterator(); iterator.hasNext(); ) {
-            CorridasDadosSrv corridasDadosSrv = (CorridasDadosSrv) iterator.next();
-            nomes.add(corridasDadosSrv.getJogadorDadosSrv().getIdUsuario());
+        List<CorridasDadosSrv> corridas = session.createQuery(
+                "from CorridasDadosSrv where tempoFim >= :ini and tempoFim <= :fim",
+                CorridasDadosSrv.class)
+                .setParameter("ini", ini.toTimestamp().getTime())
+                .setParameter("fim", fim.toTimestamp().getTime()).list();
+        for (CorridasDadosSrv c : corridas) {
+            nomes.add(c.getJogadorDadosSrv().getIdUsuario());
         }
         return nomes;
     }
@@ -134,14 +134,14 @@ public class ControlePersistencia {
         Transaction transaction = session.beginTransaction();
         try {
             jogadorDadosSrv.setLoginCriador(jogadorDadosSrv.getNome());
-            session.saveOrUpdate(jogadorDadosSrv);
+            JogadorDadosSrv managedJogador = session.merge(jogadorDadosSrv);
             CarreiraDadosSrv carreiraDadosSrv = new CarreiraDadosSrv();
             carreiraDadosSrv.setPtsAerodinamica(600);
             carreiraDadosSrv.setPtsCarro(600);
             carreiraDadosSrv.setPtsFreio(600);
             carreiraDadosSrv.setPtsPiloto(600);
-            carreiraDadosSrv.setJogadorDadosSrv(jogadorDadosSrv);
-            session.saveOrUpdate(carreiraDadosSrv);
+            carreiraDadosSrv.setJogadorDadosSrv(managedJogador);
+            session.merge(carreiraDadosSrv);
             transaction.commit();
         } catch (Exception e) {
             transaction.rollback();
@@ -152,8 +152,8 @@ public class ControlePersistencia {
     public void gravarDados(Session session, F1ManeDados... f1ManeDados) throws Exception {
         Transaction transaction = session.beginTransaction();
         try {
-            for (int i = 0; i < f1ManeDados.length; i++) {
-                session.saveOrUpdate(f1ManeDados[i]);
+            for (F1ManeDados dado : f1ManeDados) {
+                session.merge(dado);
             }
             transaction.commit();
         } catch (Exception e) {
@@ -172,20 +172,29 @@ public class ControlePersistencia {
     }
 
     public List obterListaCorridas(String nomeJogador, Session session, Integer ano) {
-        Criteria criteria = session.createCriteria(CorridasDadosSrv.class).createAlias("jogadorDadosSrv", "j")
-                .add(Restrictions.eq("j.nome", nomeJogador)).addOrder(Order.asc("tempoInicio"));
+        String hql = "from CorridasDadosSrv c join fetch c.jogadorDadosSrv j " +
+                "where j.nome = :nome";
         if (ano != null) {
             Dia ini = new Dia(1, 1, ano.intValue());
             Dia fim = new Dia(1, 1, ano.intValue() + 1);
-            criteria.add(Restrictions.ge("tempoFim", Long.valueOf(ini.toTimestamp().getTime())));
-            criteria.add(Restrictions.le("tempoFim", Long.valueOf(fim.toTimestamp().getTime())));
+            hql += " and c.tempoFim >= :ini and c.tempoFim <= :fim";
+            hql += " order by c.tempoInicio asc";
+            List<CorridasDadosSrv> corridas = session.createQuery(hql, CorridasDadosSrv.class)
+                    .setParameter("nome", nomeJogador)
+                    .setParameter("ini", ini.toTimestamp().getTime())
+                    .setParameter("fim", fim.toTimestamp().getTime()).list();
+            for (CorridasDadosSrv c : corridas) {
+                session.evict(c);
+                c.setJogadorDadosSrv(null);
+            }
+            return corridas;
         }
-
-        List corridas = criteria.list();
-        for (Iterator iterator = corridas.iterator(); iterator.hasNext(); ) {
-            CorridasDadosSrv corridasDadosSrv = (CorridasDadosSrv) iterator.next();
-            session.evict(corridasDadosSrv);
-            corridasDadosSrv.setJogadorDadosSrv(null);
+        hql += " order by c.tempoInicio asc";
+        List<CorridasDadosSrv> corridas = session.createQuery(hql, CorridasDadosSrv.class)
+                .setParameter("nome", nomeJogador).list();
+        for (CorridasDadosSrv c : corridas) {
+            session.evict(c);
+            c.setJogadorDadosSrv(null);
         }
         return corridas;
     }
@@ -194,35 +203,32 @@ public class ControlePersistencia {
         if (!Global.DATABASE) {
             return null;
         }
-        Criteria criteria = session.createCriteria(CorridasDadosSrv.class);
-        criteria.add(Restrictions.eq("circuito", circuito));
-        criteria.add(Restrictions.gt("pontos", Integer.valueOf(0)));
-        List corridas = criteria.list();
-        return corridas;
+        return session.createQuery(
+                "from CorridasDadosSrv where circuito = :circuito and pontos > 0",
+                CorridasDadosSrv.class)
+                .setParameter("circuito", circuito).list();
     }
 
     public List<CorridasDadosSrv> obterClassificacaoTemporada(String temporadaSelecionada, Session session) {
         if (!Global.DATABASE) {
             return null;
         }
-        Criteria criteria = session.createCriteria(CorridasDadosSrv.class);
-        criteria.add(Restrictions.eq("temporada", temporadaSelecionada));
-        criteria.add(Restrictions.gt("pontos", Integer.valueOf(0)));
-        List corridas = criteria.list();
-        return corridas;
+        return session.createQuery(
+                "from CorridasDadosSrv where temporada = :temporada and pontos > 0",
+                CorridasDadosSrv.class)
+                .setParameter("temporada", temporadaSelecionada).list();
     }
 
     public CarreiraDadosSrv carregaCarreiraJogador(String idUsuario, boolean vaiCliente, Session session) {
         if (!Global.DATABASE) {
             return null;
         }
-        Logger.logar("Buacar Carreira idUsuario " + idUsuario);
-        List list = session.createCriteria(CarreiraDadosSrv.class).createAlias("jogadorDadosSrv", "j")
-                .add(Restrictions.eq("j.idUsuario", idUsuario)).list();
-        CarreiraDadosSrv carreiraDadosSrv = null;
-        if (!list.isEmpty()) {
-            carreiraDadosSrv = (CarreiraDadosSrv) list.get(0);
-        }
+        Logger.logar("Buscar Carreira idUsuario " + idUsuario);
+        List<CarreiraDadosSrv> list = session.createQuery(
+                "from CarreiraDadosSrv c join fetch c.jogadorDadosSrv j where j.idUsuario = :idUsuario",
+                CarreiraDadosSrv.class)
+                .setParameter("idUsuario", idUsuario).list();
+        CarreiraDadosSrv carreiraDadosSrv = list.isEmpty() ? null : list.get(0);
         if (vaiCliente && carreiraDadosSrv != null) {
             session.evict(carreiraDadosSrv);
             carreiraDadosSrv.setJogadorDadosSrv(null);
@@ -231,23 +237,25 @@ public class ControlePersistencia {
             return null;
         }
         return carreiraDadosSrv;
-
     }
 
     public JogadorDadosSrv carregaDadosJogadorEmail(String emailJogador, Session session) {
-        List jogador = session.createCriteria(JogadorDadosSrv.class).add(Restrictions.eq("email", emailJogador)).list();
-        JogadorDadosSrv jogadorDadosSrv = (JogadorDadosSrv) (jogador.isEmpty() ? null : jogador.get(0));
-        return jogadorDadosSrv;
+        List<JogadorDadosSrv> jogador = session.createQuery(
+                "from JogadorDadosSrv where email = :email", JogadorDadosSrv.class)
+                .setParameter("email", emailJogador).list();
+        return jogador.isEmpty() ? null : jogador.get(0);
     }
 
     public List<CampeonatoSrv> obterListaCampeonatos(Session session) {
-        return session.createCriteria(CampeonatoSrv.class).addOrder(Order.desc("dataCriacao")).list();
-
+        return session.createQuery(
+                "from CampeonatoSrv order by dataCriacao desc", CampeonatoSrv.class).list();
     }
 
     public CampeonatoSrv pesquisaCampeonato(Session session, String id, boolean cliente) {
-        List campeonatos = session.createCriteria(CampeonatoSrv.class).add(Restrictions.eq("id", Long.valueOf(Long.parseLong(id)))).list();
-        CampeonatoSrv campeonato = (CampeonatoSrv) (campeonatos.isEmpty() ? null : campeonatos.get(0));
+        List<CampeonatoSrv> campeonatos = session.createQuery(
+                "from CampeonatoSrv where id = :id", CampeonatoSrv.class)
+                .setParameter("id", Long.parseLong(id)).list();
+        CampeonatoSrv campeonato = campeonatos.isEmpty() ? null : campeonatos.get(0);
         if (campeonato == null) {
             return null;
         }
@@ -255,15 +263,15 @@ public class ControlePersistencia {
             campeonatoCliente(session, campeonato);
         }
         return campeonato;
-
     }
 
     public List pesquisaCampeonatos(String idUsuario, Session session, boolean cliente) {
-        List campeonatos = session.createCriteria(CampeonatoSrv.class).createAlias("jogadorDadosSrv", "j")
-                .add(Restrictions.eq("j.idUsuario", idUsuario)).list();
+        List<CampeonatoSrv> campeonatos = session.createQuery(
+                "from CampeonatoSrv c join fetch c.jogadorDadosSrv j where j.idUsuario = :idUsuario",
+                CampeonatoSrv.class)
+                .setParameter("idUsuario", idUsuario).list();
         if (cliente) {
-            for (Iterator iterator = campeonatos.iterator(); iterator.hasNext(); ) {
-                CampeonatoSrv campeonato = (CampeonatoSrv) iterator.next();
+            for (CampeonatoSrv campeonato : campeonatos) {
                 campeonatoCliente(session, campeonato);
             }
         }
@@ -271,11 +279,13 @@ public class ControlePersistencia {
     }
 
     public List pesquisaCampeonatosEmAberto(String idUsuario, Session session, boolean cliente) {
-        List campeonatos = session.createCriteria(CampeonatoSrv.class).createAlias("jogadorDadosSrv", "j")
-                .add(Restrictions.eq("j.idUsuario", idUsuario)).add(Restrictions.eq("finalizado", Boolean.FALSE)).list();
+        List<CampeonatoSrv> campeonatos = session.createQuery(
+                "from CampeonatoSrv c join fetch c.jogadorDadosSrv j " +
+                "where j.idUsuario = :idUsuario and c.finalizado = false",
+                CampeonatoSrv.class)
+                .setParameter("idUsuario", idUsuario).list();
         if (cliente) {
-            for (Iterator iterator = campeonatos.iterator(); iterator.hasNext(); ) {
-                CampeonatoSrv campeonato = (CampeonatoSrv) iterator.next();
+            for (CampeonatoSrv campeonato : campeonatos) {
                 campeonatoCliente(session, campeonato);
             }
         }
@@ -283,8 +293,10 @@ public class ControlePersistencia {
     }
 
     public CampeonatoSrv pesquisaCampeonatoId(String id, Session session) {
-        CampeonatoSrv campeonatoSrv = (CampeonatoSrv) session.createCriteria(CampeonatoSrv.class)
-                .add(Restrictions.eq("id", Long.valueOf(Long.parseLong(id)))).uniqueResult();
+        CampeonatoSrv campeonatoSrv = session.createQuery(
+                "from CampeonatoSrv where id = :id", CampeonatoSrv.class)
+                .setParameter("id", Long.parseLong(id))
+                .uniqueResultOptional().orElse(null);
         campeonatoCliente(session, campeonatoSrv);
         return campeonatoSrv;
     }
@@ -308,9 +320,9 @@ public class ControlePersistencia {
     }
 
     public List pesquisaCampeonatos(JogadorDadosSrv jogadorDadosSrv, Session session) {
-        List campeonatos = session.createCriteria(CampeonatoSrv.class)
-                .add(Restrictions.eq("jogadorDadosSrv", jogadorDadosSrv)).list();
-        return campeonatos;
+        return session.createQuery(
+                "from CampeonatoSrv where jogadorDadosSrv = :jogador", CampeonatoSrv.class)
+                .setParameter("jogador", jogadorDadosSrv).list();
     }
 
     public MsgSrv modoCarreira(String idUsuario, boolean modo) {
@@ -340,19 +352,29 @@ public class ControlePersistencia {
     }
 
     public boolean existeNomeCarro(Session session, String nomeCarro, Long idJogador) {
-        List list = session.createCriteria(CarreiraDadosSrv.class).createAlias("jogadorDadosSrv", "j")
-                .add(Restrictions.ne("j.id", idJogador)).add(Restrictions.eq("nomeCarro", nomeCarro)).list();
+        List<CarreiraDadosSrv> list = session.createQuery(
+                "from CarreiraDadosSrv c join fetch c.jogadorDadosSrv j " +
+                "where j.id <> :idJogador and c.nomeCarro = :nomeCarro",
+                CarreiraDadosSrv.class)
+                .setParameter("idJogador", idJogador)
+                .setParameter("nomeCarro", nomeCarro).list();
         return !list.isEmpty();
     }
 
     public boolean existeNomePiloto(Session session, String nomePiloto, Long idJogador) {
-        List list = session.createCriteria(CarreiraDadosSrv.class).createAlias("jogadorDadosSrv", "j")
-                .add(Restrictions.ne("j.id", idJogador)).add(Restrictions.eq("nomePiloto", nomePiloto)).list();
+        List<CarreiraDadosSrv> list = session.createQuery(
+                "from CarreiraDadosSrv c join fetch c.jogadorDadosSrv j " +
+                "where j.id <> :idJogador and c.nomePiloto = :nomePiloto",
+                CarreiraDadosSrv.class)
+                .setParameter("idJogador", idJogador)
+                .setParameter("nomePiloto", nomePiloto).list();
         return !list.isEmpty();
     }
 
     public boolean existeNomeCampeonato(Session session, String nome) {
-        List list = session.createCriteria(CampeonatoSrv.class).add(Restrictions.eq("nome", nome)).list();
+        List<CampeonatoSrv> list = session.createQuery(
+                "from CampeonatoSrv where nome = :nome", CampeonatoSrv.class)
+                .setParameter("nome", nome).list();
         return !list.isEmpty();
     }
 
@@ -360,20 +382,15 @@ public class ControlePersistencia {
         if (!Global.DATABASE) {
             return null;
         }
-        Criteria criteria = session.createCriteria(CorridasDadosSrv.class);
-        criteria.add(Restrictions.gt("pontos", Integer.valueOf(0)));
-        List corridas = criteria.list();
-        return corridas;
+        return session.createQuery(
+                "from CorridasDadosSrv where pontos > 0", CorridasDadosSrv.class).list();
     }
 
     public List obterClassificacaoEquipes(Session session) {
-        Criteria criteria = session.createCriteria(CarreiraDadosSrv.class);
-        criteria.add(Restrictions.isNotNull("nomeCarro"));
-        criteria.add(Restrictions.isNotNull("nomePiloto"));
-        criteria.add(Restrictions.gt("ptsConstrutoresGanhos", Integer.valueOf(0)));
-        criteria.addOrder(Order.desc("ptsConstrutoresGanhos"));
-        List carreiras = criteria.list();
-        return carreiras;
+        return session.createQuery(
+                "from CarreiraDadosSrv where nomeCarro is not null and nomePiloto is not null " +
+                "and ptsConstrutoresGanhos > 0 order by ptsConstrutoresGanhos desc",
+                CarreiraDadosSrv.class).list();
     }
 
     public void carreiraDadosParaPiloto(CarreiraDadosSrv carreiraDadosSrv, Piloto piloto) {
@@ -396,14 +413,12 @@ public class ControlePersistencia {
             piloto.setIdCapaceteLivery(carreiraDadosSrv.getIdCapaceteLivery().toString());
         } else {
             piloto.setIdCapaceteLivery(Util.rgb2hex(carreiraDadosSrv.geraCor2()));
-
         }
         if (carreiraDadosSrv.getTemporadaCarroLivery() != null && carreiraDadosSrv.getIdCarroLivery() != null
                 && carreiraDadosSrv.getIdCarroLivery().intValue() != 0) {
             piloto.setIdCarroLivery(carreiraDadosSrv.getIdCarroLivery().toString());
         } else {
             piloto.setIdCarroLivery(Util.rgb2hex(carreiraDadosSrv.geraCor2()));
-
         }
         piloto.setNomeCarro(carreiraDadosSrv.getNomeCarro());
         piloto.setHabilidade(carreiraDadosSrv.getPtsPiloto());
@@ -420,11 +435,12 @@ public class ControlePersistencia {
     public List obterClassificacaoCampeonato(Session session) {
         Dia umMesAtras = new Dia();
         umMesAtras.advance(-15);
-        String hql = "from CampeonatoSrv obj where obj.id in (select distinct obj2.id from  CampeonatoSrv obj2 inner join  obj2.corridaCampeonatos cc where cc.tempoFim >= :tempoFim)";
-        Query qry = session.createQuery(hql);
-        qry.setParameter("tempoFim", Long.valueOf(umMesAtras.toTimestamp().getTime()));
-        List list = qry.list();
-        return list;
+        String hql = "from CampeonatoSrv obj where obj.id in " +
+                "(select distinct obj2.id from CampeonatoSrv obj2 inner join obj2.corridaCampeonatos cc " +
+                "where cc.tempoFim >= :tempoFim)";
+        return session.createQuery(hql, CampeonatoSrv.class)
+                .setParameter("tempoFim", umMesAtras.toTimestamp().getTime())
+                .list();
     }
 
 }

--- a/src/main/java/br/f1mane/servidor/entidades/persistencia/CampeonatoSrv.java
+++ b/src/main/java/br/f1mane/servidor/entidades/persistencia/CampeonatoSrv.java
@@ -3,14 +3,14 @@ package br.f1mane.servidor.entidades.persistencia;
 import java.util.LinkedList;
 import java.util.List;
 
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.JoinColumn;
-import javax.persistence.OneToMany;
-import javax.persistence.OneToOne;
-import javax.persistence.Table;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
 
 @Entity
 @Table(name = "f1_campeonatosrv")

--- a/src/main/java/br/f1mane/servidor/entidades/persistencia/CarreiraDadosSrv.java
+++ b/src/main/java/br/f1mane/servidor/entidades/persistencia/CarreiraDadosSrv.java
@@ -3,11 +3,11 @@ package br.f1mane.servidor.entidades.persistencia;
 import java.awt.Color;
 import java.io.Serializable;
 
-import javax.persistence.Entity;
-import javax.persistence.JoinColumn;
-import javax.persistence.OneToOne;
-import javax.persistence.Table;
-import javax.persistence.Transient;
+import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/src/main/java/br/f1mane/servidor/entidades/persistencia/CorridaCampeonatoSrv.java
+++ b/src/main/java/br/f1mane/servidor/entidades/persistencia/CorridaCampeonatoSrv.java
@@ -3,13 +3,13 @@ package br.f1mane.servidor.entidades.persistencia;
 import java.util.LinkedList;
 import java.util.List;
 
-import javax.persistence.CascadeType;
-import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
-import javax.persistence.Table;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
 
 @Entity
 @Table(name = "f1_corridacampeonatosrv")

--- a/src/main/java/br/f1mane/servidor/entidades/persistencia/CorridasDadosSrv.java
+++ b/src/main/java/br/f1mane/servidor/entidades/persistencia/CorridasDadosSrv.java
@@ -2,13 +2,11 @@ package br.f1mane.servidor.entidades.persistencia;
 
 import java.io.Serializable;
 
-import javax.persistence.Entity;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
+import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 
-import br.nnpe.Util;
-import br.f1mane.controles.InterfaceJogo;
 
 /**
  * @author Paulo Sobreira Criado em 27/10/2007 as 18:47:15

--- a/src/main/java/br/f1mane/servidor/entidades/persistencia/DadosCorridaCampeonatoSrv.java
+++ b/src/main/java/br/f1mane/servidor/entidades/persistencia/DadosCorridaCampeonatoSrv.java
@@ -1,9 +1,9 @@
 package br.f1mane.servidor.entidades.persistencia;
 
-import javax.persistence.Entity;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.Transient;
+import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Transient;
 
 /**
  * @author Paulo Sobreira Criado em 27/10/2007 as 18:47:15

--- a/src/main/java/br/f1mane/servidor/entidades/persistencia/F1ManeDados.java
+++ b/src/main/java/br/f1mane/servidor/entidades/persistencia/F1ManeDados.java
@@ -3,17 +3,17 @@ package br.f1mane.servidor.entidades.persistencia;
 import java.io.Serializable;
 import java.util.Date;
 
-import javax.persistence.Column;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.MappedSuperclass;
+import jakarta.persistence.Column;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
 
 @MappedSuperclass
 public abstract class F1ManeDados implements Serializable {
 
 	@Id
-	@GeneratedValue(strategy = GenerationType.AUTO)
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	protected Long id;
 
 	@Column(nullable = false)

--- a/src/main/java/br/f1mane/servidor/entidades/persistencia/JogadorDadosSrv.java
+++ b/src/main/java/br/f1mane/servidor/entidades/persistencia/JogadorDadosSrv.java
@@ -4,12 +4,12 @@ import java.io.Serializable;
 import java.util.LinkedList;
 import java.util.List;
 
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.OneToMany;
-import javax.persistence.Table;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
 
 /**
  * @author Paulo Sobreira Criado em 20/10/2007 as 15:27:53

--- a/src/main/java/br/f1mane/servidor/rest/LetsRace.java
+++ b/src/main/java/br/f1mane/servidor/rest/LetsRace.java
@@ -15,15 +15,15 @@ import java.util.Set;
 import java.util.Vector;
 
 import javax.imageio.ImageIO;
-import javax.ws.rs.GET;
-import javax.ws.rs.HeaderParam;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 
 import br.f1mane.servidor.controles.ControleJogosServer;
 import br.f1mane.servidor.controles.ControlePaddockServidor;
@@ -951,7 +951,7 @@ public class LetsRace {
         sessaoCliente.setUlimaAtividade(System.currentTimeMillis());
         Object ret = null;
         try {
-            ret = controlePaddock.criarCampeonato(campeonato, token);
+            ret = controlePaddock.criarCampeonato(campeonato, sessaoCliente.getIdUsuario());
         } catch (Exception e) {
             Logger.logarExept(e);
         }
@@ -975,7 +975,7 @@ public class LetsRace {
         sessaoCliente.setUlimaAtividade(System.currentTimeMillis());
         Object ret = null;
         try {
-            ret = controlePaddock.finalizaCampeonato(campeonato, token);
+            ret = controlePaddock.finalizaCampeonato(campeonato, sessaoCliente.getIdUsuario());
         } catch (Exception e) {
             Logger.logarExept(e);
         }
@@ -1000,7 +1000,7 @@ public class LetsRace {
 
         CampeonatoTO campeonato = null;
         try {
-            campeonato = controlePaddock.obterCampeonatoEmAberto(token);
+            campeonato = controlePaddock.obterCampeonatoEmAberto(sessaoCliente.getIdUsuario());
         } catch (Exception e) {
             Logger.logarExept(e);
         }

--- a/src/main/java/br/f1mane/servidor/servlet/ServletPaddock.java
+++ b/src/main/java/br/f1mane/servidor/servlet/ServletPaddock.java
@@ -6,33 +6,17 @@ import br.f1mane.servidor.PaddockConstants;
 import br.f1mane.servidor.PaddockServer;
 import br.f1mane.servidor.controles.ControlePaddockServidor;
 import br.f1mane.servidor.entidades.TOs.SessaoCliente;
-import br.f1mane.servidor.entidades.persistencia.*;
 import br.f1mane.servidor.util.ZipUtil;
 import br.nnpe.FormatDate;
 import br.nnpe.Logger;
 import br.nnpe.Util;
-import org.hibernate.boot.MetadataSources;
-import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
-import org.hibernate.cfg.AvailableSettings;
-import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
-import org.hibernate.tool.hbm2ddl.SchemaExport;
-import org.hibernate.tool.schema.TargetType;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
+import jakarta.persistence.Persistence;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.xml.XMLConstants;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import java.io.*;
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.util.*;
 
@@ -198,52 +182,10 @@ public class ServletPaddock extends HttpServlet {
         res.flushBuffer();
     }
 
-    private void createSchema(PrintWriter printWriter)
-            throws Exception {
-        SchemaExport export = new SchemaExport();
-        export.create(EnumSet.of(TargetType.DATABASE), getMetaData().buildMetadata());
-    }
-
-    private MetadataSources getMetaData() throws Exception {
-        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-        dbf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-        DocumentBuilder db = dbf.newDocumentBuilder();
-        Document doc = db.parse(CarregadorRecursos.recursoComoStream("META-INF/persistence.xml"));
-        NodeList list = doc.getElementsByTagName("property");
-        String url = null, pass = null, user = null, driver = null;
-        for (int temp = 0; temp < list.getLength(); temp++) {
-            Node node = list.item(temp);
-            if (node.getNodeType() == Node.ELEMENT_NODE) {
-                Element element = (Element) node;
-                String attr = element.getAttribute("name");
-                if ("javax.persistence.jdbc.url".equals(attr)) {
-                    url = element.getAttribute("value");
-                } else if ("javax.persistence.jdbc.user".equals(attr)) {
-                    user = element.getAttribute("value");
-                } else if ("javax.persistence.jdbc.password".equals(attr)) {
-                    pass = element.getAttribute("value");
-                } else if ("javax.persistence.jdbc.driver".equals(attr)) {
-                    driver = element.getAttribute("value");
-                }
-            }
-        }
-        Class.forName(driver);
-        Connection connection =
-                DriverManager.getConnection(url, user, pass);
-        MetadataSources metadata = new MetadataSources(
-                new StandardServiceRegistryBuilder()
-                        .applySetting("hibernate.dialect", "org.hibernate.dialect.MySQL8Dialect")
-                        .applySetting(AvailableSettings.CONNECTION_PROVIDER, new MyConnectionProvider(connection))
-                        .build());
-        metadata.addAnnotatedClass(F1ManeDados.class);
-        metadata.addAnnotatedClass(JogadorDadosSrv.class);
-        metadata.addAnnotatedClass(CampeonatoSrv.class);
-        metadata.addAnnotatedClass(CarreiraDadosSrv.class);
-        metadata.addAnnotatedClass(CorridaCampeonatoSrv.class);
-        metadata.addAnnotatedClass(CorridasDadosSrv.class);
-        metadata.addAnnotatedClass(DadosCorridaCampeonatoSrv.class);
-        metadata.addAnnotatedClass(PaddockDadosSrv.class);
-        return metadata;
+    private void createSchema(PrintWriter printWriter) throws Exception {
+        Map<String, Object> props = new HashMap<>();
+        props.put("jakarta.persistence.schema-generation.database.action", "create");
+        Persistence.generateSchema("flmane-jpa", props);
     }
 
     private void topExceptions(HttpServletResponse res) throws IOException {
@@ -301,38 +243,5 @@ public class ServletPaddock extends HttpServlet {
         printWriter.write("<meta http-equiv='Content-Type' content='text/html; charset=utf-8'>");
         printWriter.write("<meta name='viewport' content='width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no'>");
         printWriter.write("</head>");
-    }
-
-
-    private static class MyConnectionProvider implements ConnectionProvider {
-        private final Connection connection;
-
-        public MyConnectionProvider(Connection connection) {
-            this.connection = connection;
-        }
-
-        @Override
-        public boolean isUnwrappableAs(Class unwrapType) {
-            return false;
-        }
-
-        @Override
-        public <T> T unwrap(Class<T> unwrapType) {
-            return null;
-        }
-
-        @Override
-        public Connection getConnection() {
-            return connection; // Interesting part here
-        }
-
-        @Override
-        public void closeConnection(Connection conn) throws SQLException {
-        }
-
-        @Override
-        public boolean supportsAggressiveRelease() {
-            return true;
-        }
     }
 }

--- a/src/main/java/br/f1mane/servidor/util/Compress.java
+++ b/src/main/java/br/f1mane/servidor/util/Compress.java
@@ -3,7 +3,7 @@ package br.f1mane.servidor.util;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
-import javax.ws.rs.NameBinding;
+import jakarta.ws.rs.NameBinding;
 
 //@Compress annotation is the name binding annotation
 @NameBinding

--- a/src/main/java/br/f1mane/servidor/util/GZIPWriterInterceptor.java
+++ b/src/main/java/br/f1mane/servidor/util/GZIPWriterInterceptor.java
@@ -4,11 +4,11 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.zip.GZIPOutputStream;
 
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.ext.Provider;
-import javax.ws.rs.ext.WriterInterceptor;
-import javax.ws.rs.ext.WriterInterceptorContext;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.ext.Provider;
+import jakarta.ws.rs.ext.WriterInterceptor;
+import jakarta.ws.rs.ext.WriterInterceptorContext;
 
 @Provider
 @Compress

--- a/src/main/java/br/f1mane/servidor/util/HibernateUtil.java
+++ b/src/main/java/br/f1mane/servidor/util/HibernateUtil.java
@@ -1,8 +1,8 @@
 package br.f1mane.servidor.util;
 
-import javax.persistence.EntityManager;
-import javax.persistence.EntityManagerFactory;
-import javax.persistence.Persistence;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.Persistence;
 
 import org.hibernate.Session;
 

--- a/src/main/java/br/nnpe/FormatNumber.java
+++ b/src/main/java/br/nnpe/FormatNumber.java
@@ -278,7 +278,7 @@ public class FormatNumber extends Object {
 				NUMBER1 = NUMBER1.substring(0, NUMBER1.indexOf("."));
 			}
 			try {
-				resultado = (new Integer(NUMBER1)).intValue();
+				resultado = Integer.parseInt(NUMBER1);
 			} catch (Exception e) {
 				resultado = 0;
 			}
@@ -300,7 +300,7 @@ public class FormatNumber extends Object {
 				NUMBER1 = NUMBER1.substring(0, NUMBER1.indexOf("."));
 			}
 			try {
-				resultado = new Integer(NUMBER1);
+				resultado = Integer.valueOf(NUMBER1);
 			} catch (Exception e) {
 				resultado = null;
 			}
@@ -322,7 +322,7 @@ public class FormatNumber extends Object {
 				NUMBER1 = NUMBER1.substring(0, NUMBER1.indexOf("."));
 			}
 			try {
-				resultado = (new Long(NUMBER1)).longValue();
+				resultado = Long.parseLong(NUMBER1);
 			} catch (Exception e) {
 				resultado = 0;
 			}
@@ -344,7 +344,7 @@ public class FormatNumber extends Object {
 				NUMBER1 = NUMBER1.substring(0, NUMBER1.indexOf("."));
 			}
 			try {
-				resultado = new Long(NUMBER1);
+				resultado = Long.valueOf(NUMBER1);
 			} catch (Exception e) {
 				resultado = null;
 			}
@@ -377,7 +377,7 @@ public class FormatNumber extends Object {
 	 */
 	public static int parseInt(double NUMBER) {
 		try {
-			Double D = new Double(NUMBER);
+			Double D = Double.valueOf(NUMBER);
 			return D.intValue();
 		} catch (Exception e) {
 			return 0;
@@ -395,7 +395,7 @@ public class FormatNumber extends Object {
 			NUMBER1 = NUMBER1.trim();
 			NUMBER1 = checkDouble(NUMBER1);
 			try {
-				resultado = (new Double(NUMBER1)).doubleValue();
+				resultado = Double.parseDouble(NUMBER1);
 			} catch (Exception e) {
 				resultado = 0;
 			}
@@ -414,7 +414,7 @@ public class FormatNumber extends Object {
 			NUMBER1 = NUMBER1.trim();
 			NUMBER1 = checkDouble(NUMBER1);
 			try {
-				resultado = new Double(NUMBER1);
+				resultado = Double.valueOf(NUMBER1);
 			} catch (Exception e) {
 				resultado = null;
 			}
@@ -472,7 +472,7 @@ public class FormatNumber extends Object {
 		if (NUMBER1 != null && NUMBER1.length() > 0) {
 			NUMBER1 = NUMBER1.trim();
 			NUMBER1 = checkInt(NUMBER1);
-			resultado = new Integer(NUMBER1);
+			resultado = Integer.valueOf(NUMBER1);
 		}
 		return resultado;
 	}
@@ -483,7 +483,7 @@ public class FormatNumber extends Object {
 		if (NUMBER1 != null && NUMBER1.length() > 0) {
 			NUMBER1 = NUMBER1.trim();
 			NUMBER1 = checkInt(NUMBER1);
-			resultado = new Integer(NUMBER1);
+			resultado = Integer.valueOf(NUMBER1);
 		}
 		return resultado;
 	}
@@ -494,7 +494,7 @@ public class FormatNumber extends Object {
 		if (NUMBER1 != null && NUMBER1.length() > 0) {
 			NUMBER1 = NUMBER1.trim();
 			NUMBER1 = checkDouble(NUMBER1);
-			resultado = new Double(NUMBER1);
+			resultado = Double.valueOf(NUMBER1);
 		}
 		return resultado;
 	}
@@ -505,7 +505,7 @@ public class FormatNumber extends Object {
 		if (NUMBER1 != null && NUMBER1.length() > 0) {
 			NUMBER1 = NUMBER1.trim();
 			NUMBER1 = checkInt(NUMBER1);
-			resultado = new Long(NUMBER1);
+			resultado = Long.valueOf(NUMBER1);
 		}
 		return resultado;
 	}

--- a/src/main/java/br/nnpe/Numero.java
+++ b/src/main/java/br/nnpe/Numero.java
@@ -4,7 +4,7 @@ public class Numero {
 	private Double numero;
 
 	public Numero(Integer ptsCarreira) {
-		this.numero = new Double(ptsCarreira.doubleValue());
+		this.numero = ptsCarreira.doubleValue();
 	}
 
 	public Double getNumero() {

--- a/src/main/java/br/nnpe/Util.java
+++ b/src/main/java/br/nnpe/Util.java
@@ -232,7 +232,7 @@ public class Util {
 	 */
 	public static Integer integerOrNull(int num) {
 		if (num != 0) {
-			return new Integer(num);
+			return Integer.valueOf(num);
 		}
 
 		return null;
@@ -243,7 +243,7 @@ public class Util {
 	 */
 	public static Double doubleOrNull(double num) {
 		if (num != 0) {
-			return new Double(num);
+			return Double.valueOf(num);
 		}
 
 		return null;
@@ -472,7 +472,7 @@ public class Util {
 
 	public static Long extrairNumerosLong(String string) {
 		try {
-			return new Long(extrairNumeros(string));
+			return Long.valueOf(extrairNumeros(string));
 		} catch (Exception e) {
 		}
 		return null;

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -1,18 +1,25 @@
-<persistence version="2.2"
-             xmlns="http://xmlns.jcp.org/xml/ns/persistence">
+<persistence version="3.2"
+             xmlns="https://jakarta.ee/xml/ns/persistence">
     <persistence-unit name="flmane-jpa" transaction-type="RESOURCE_LOCAL">
+        <class>br.f1mane.servidor.entidades.persistencia.JogadorDadosSrv</class>
+        <class>br.f1mane.servidor.entidades.persistencia.CarreiraDadosSrv</class>
+        <class>br.f1mane.servidor.entidades.persistencia.CorridasDadosSrv</class>
+        <class>br.f1mane.servidor.entidades.persistencia.CampeonatoSrv</class>
+        <class>br.f1mane.servidor.entidades.persistencia.CorridaCampeonatoSrv</class>
+        <class>br.f1mane.servidor.entidades.persistencia.DadosCorridaCampeonatoSrv</class>
+        <exclude-unlisted-classes>true</exclude-unlisted-classes>
         <properties>
             <property
-                    name="javax.persistence.jdbc.driver"
+                    name="jakarta.persistence.jdbc.driver"
                     value="${jdbc.driver}"/>
             <property
-                    name="javax.persistence.jdbc.url"
+                    name="jakarta.persistence.jdbc.url"
                     value="${jdbc.url}"/>
             <property
-                    name="javax.persistence.jdbc.user"
+                    name="jakarta.persistence.jdbc.user"
                     value="${jdbc.user}"/>
             <property
-                    name="javax.persistence.jdbc.password"
+                    name="jakarta.persistence.jdbc.password"
                     value="${jdbc.password}"/>
             <property
                     name="hibernate.dialect"
@@ -21,7 +28,6 @@
                     name="hibernate.hbm2ddl.auto"
                     value="update"/>
             <property name="hibernate.format_sql" value="true"/>
-            <property name="hibernate.hbm2ddl.auto" value="update"/>
         </properties>
     </persistence-unit>
 </persistence>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,9 +1,9 @@
-#Sat, 27 Jun 2026 20:03:17 -0300
+#Mon, 29 Jun 2026 13:33:02 -0300
 port=80
 host=localhost
 #senha padrao em md5: f1mane
 senha=f5f01f7accfcd0b99a18317fa7e21b14
-versao=6.855
+versao=6.878
 versaoMesAno=06-2026
 idGoogle=143142801251-n0a6bc0rs03h41bt7ganklmlrokqn6te.apps.googleusercontent.com
 applet=true

--- a/src/main/webapp/html5/campeonato.html
+++ b/src/main/webapp/html5/campeonato.html
@@ -5,7 +5,7 @@
 <meta name="viewport"
 	content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 <link rel="stylesheet" href="../bootstrap/css/bootstrap.min.css">
-<link rel="stylesheet" href="css/flmane.css?v=6.854">
+<link rel="stylesheet" href="css/flmane.css?v=6.877">
 <script src="../jquery/jquery-3.2.1.min.js"></script>
 <script src="../bootstrap/js/bootstrap.min.js"></script>
 
@@ -218,13 +218,13 @@
 		</div>				
 		<footer class="footer">
 			<div class="container">
-				<p>Build: 6.854</p>
+				<p>Build: 6.877</p>
 			</div>
 		</footer>
 	</div>
 </body>
-<script src="js/util.js?v=6.854"></script>
-<script src="js/loader.js?v=6.854"></script>
-<script src="js/lang.js?v=6.854"></script>
-<script src="js/campeonato.js?v=6.854"></script>
+<script src="js/util.js?v=6.877"></script>
+<script src="js/loader.js?v=6.877"></script>
+<script src="js/lang.js?v=6.877"></script>
+<script src="js/campeonato.js?v=6.877"></script>
 </html>

--- a/src/main/webapp/html5/classificacao.html
+++ b/src/main/webapp/html5/classificacao.html
@@ -5,8 +5,8 @@
 <meta name="viewport"
 	content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 <link rel="stylesheet" href="../bootstrap/css/bootstrap.min.css">
-<link rel="stylesheet" href="css/flmane.css?v=6.854">
-<link rel="stylesheet" href="css/mdb-btns.css?v=6.854">
+<link rel="stylesheet" href="css/flmane.css?v=6.877">
+<link rel="stylesheet" href="css/mdb-btns.css?v=6.877">
 <script src="../jquery/jquery-3.2.1.min.js"></script>
 <script src="../bootstrap/js/bootstrap.min.js"></script>
 
@@ -15,7 +15,7 @@
 <body class="body">
 <div id="f1body">
 	<section id="head" class="container" style="margin: 10px;">
-        <a href="index.html?v=6.854" id="voltar" class="voltar black">
+        <a href="index.html?v=6.877" id="voltar" class="voltar black">
           <span class="glyphicon glyphicon glyphicon-chevron-left" aria-hidden="true"></span> 
         </a>
 		<h3 style="display: inline;">Fl-Mane</h3>
@@ -27,34 +27,34 @@
 	</section>
 	<section id="mainContainer" class="container">
 		<div id="botoes" class="list-group">
-			<a href="classificacao_geral.html?v=6.854" class="list-group-item transparent">
+			<a href="classificacao_geral.html?v=6.877" class="list-group-item transparent">
 				<button type="button" id="classificacao_geral" class="btn btn-default btn-block btn-raised bgTransparent"></button>
 			</a> 
-			<a href="classificacao_circuito.html?v=6.854" class="list-group-item transparent">
+			<a href="classificacao_circuito.html?v=6.877" class="list-group-item transparent">
 				<button type="button" id="classificacao_circuito" class="btn btn-default btn-block btn-raised bgTransparent"></button>
 			</a>
-			<a href="classificacao_temporada.html?v=6.854" class="list-group-item transparent">
+			<a href="classificacao_temporada.html?v=6.877" class="list-group-item transparent">
 				<button type="button" id="classificacao_temporada" class="btn btn-default btn-block btn-raised bgTransparent"></button>
 			</a>
-			<a href="classificacao_equipes.html?v=6.854" class="list-group-item transparent">
+			<a href="classificacao_equipes.html?v=6.877" class="list-group-item transparent">
 				<button type="button" id="classificacao_equipes" class="btn btn-default btn-block btn-raised bgTransparent">classificacao_equipes</button>
 			</a>
-			<a href="classificacao_campeonato.html?v=6.854" class="list-group-item transparent">
+			<a href="classificacao_campeonato.html?v=6.877" class="list-group-item transparent">
 				<button type="button" id="classificacao_campeonato" class="btn btn-default btn-block btn-raised bgTransparent">classificacao_equipes</button>
 			</a>						
 		</div>
 	</section>
 	<footer class="footer">
 		<div class="container">
-			<p>Build: 6.854</p>
+			<p>Build: 6.877</p>
 		</div>
 	</footer>
 </div>	
 </body>
-<script src="js/util.js?v=6.854"></script>
-<script src="js/loader.js?v=6.854"></script>
-<script src="js/lang.js?v=6.854"></script>
-<script src="js/classificacao.js?v=6.854"></script>
+<script src="js/util.js?v=6.877"></script>
+<script src="js/loader.js?v=6.877"></script>
+<script src="js/lang.js?v=6.877"></script>
+<script src="js/classificacao.js?v=6.877"></script>
 <script>
 //Ripple-effect animation
 (function($) {

--- a/src/main/webapp/html5/classificacao_campeonato.html
+++ b/src/main/webapp/html5/classificacao_campeonato.html
@@ -5,8 +5,8 @@
 <meta name="viewport"
 	content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 <link rel="stylesheet" href="../bootstrap/css/bootstrap.min.css">
-<link rel="stylesheet" href="css/flmane.css?v=6.854">
-<link rel="stylesheet" href="css/mdb-btns.css?v=6.854">
+<link rel="stylesheet" href="css/flmane.css?v=6.877">
+<link rel="stylesheet" href="css/mdb-btns.css?v=6.877">
 <script src="../jquery/jquery-3.2.1.min.js"></script>
 <script src="../bootstrap/js/bootstrap.min.js"></script>
 
@@ -118,13 +118,13 @@
 		</section>
 		<footer class="footer">
 			<div class="container">
-				<p>Build: 6.854</p>
+				<p>Build: 6.877</p>
 			</div>
 		</footer>
 	</div>
 </body>
-<script src="js/util.js?v=6.854"></script>
-<script src="js/loader.js?v=6.854"></script>
-<script src="js/lang.js?v=6.854"></script>
-<script src="js/classificacao_campeonato.js?v=6.854"></script>
+<script src="js/util.js?v=6.877"></script>
+<script src="js/loader.js?v=6.877"></script>
+<script src="js/lang.js?v=6.877"></script>
+<script src="js/classificacao_campeonato.js?v=6.877"></script>
 </html>

--- a/src/main/webapp/html5/classificacao_circuito.html
+++ b/src/main/webapp/html5/classificacao_circuito.html
@@ -5,8 +5,8 @@
 <meta name="viewport"
 	content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 <link rel="stylesheet" href="../bootstrap/css/bootstrap.min.css">
-<link rel="stylesheet" href="css/flmane.css?v=6.854">
-<link rel="stylesheet" href="css/mdb-btns.css?v=6.854">
+<link rel="stylesheet" href="css/flmane.css?v=6.877">
+<link rel="stylesheet" href="css/mdb-btns.css?v=6.877">
 <script src="../jquery/jquery-3.2.1.min.js"></script>
 <script src="../bootstrap/js/bootstrap.min.js"></script>
 
@@ -15,7 +15,7 @@
 <body class="body">
 <div id="f1body">
 	<section id="head" class="container" style="margin: 10px;">
-        <a href="classificacao.html?v=6.854" id="voltar" class="voltar black">
+        <a href="classificacao.html?v=6.877" id="voltar" class="voltar black">
           <span class="glyphicon glyphicon glyphicon-chevron-left" aria-hidden="true"></span> 
         </a>
 		<h3 style="display: inline;">Fl-Mane</h3>
@@ -58,13 +58,13 @@
 	</section>
 	<footer class="footer">
 		<div class="container">
-			<p>Build: 6.854</p>
+			<p>Build: 6.877</p>
 		</div>
 	</footer>
 </div>	
 </body>
-<script src="js/util.js?v=6.854"></script>
-<script src="js/loader.js?v=6.854"></script>
-<script src="js/lang.js?v=6.854"></script>
-<script src="js/classificacao_circuito.js?v=6.854"></script>
+<script src="js/util.js?v=6.877"></script>
+<script src="js/loader.js?v=6.877"></script>
+<script src="js/lang.js?v=6.877"></script>
+<script src="js/classificacao_circuito.js?v=6.877"></script>
 </html>

--- a/src/main/webapp/html5/classificacao_equipes.html
+++ b/src/main/webapp/html5/classificacao_equipes.html
@@ -5,8 +5,8 @@
 <meta name="viewport"
 	content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 <link rel="stylesheet" href="../bootstrap/css/bootstrap.min.css">
-<link rel="stylesheet" href="css/flmane.css?v=6.854">
-<link rel="stylesheet" href="css/mdb-btns.css?v=6.854">
+<link rel="stylesheet" href="css/flmane.css?v=6.877">
+<link rel="stylesheet" href="css/mdb-btns.css?v=6.877">
 <script src="../jquery/jquery-3.2.1.min.js"></script>
 <script src="../bootstrap/js/bootstrap.min.js"></script>
 
@@ -15,7 +15,7 @@
 <body class="body">
 <div id="f1body">
 	<section id="head" class="container" style="margin: 10px;">
-        <a href="classificacao.html?v=6.854" id="voltar" class="voltar black">
+        <a href="classificacao.html?v=6.877" id="voltar" class="voltar black">
           <span class="glyphicon glyphicon glyphicon-chevron-left" aria-hidden="true"></span> 
         </a>
 		<h3 style="display: inline;">Fl-Mane</h3>
@@ -37,13 +37,13 @@
 	</section>
 	<footer class="footer">
 		<div class="container">
-			<p>Build: 6.854</p>
+			<p>Build: 6.877</p>
 		</div>
 	</footer>
 </div>	
 </body>
-<script src="js/util.js?v=6.854"></script>
-<script src="js/loader.js?v=6.854"></script>
-<script src="js/lang.js?v=6.854"></script>
-<script src="js/classificacao_equipes.js?v=6.854"></script>
+<script src="js/util.js?v=6.877"></script>
+<script src="js/loader.js?v=6.877"></script>
+<script src="js/lang.js?v=6.877"></script>
+<script src="js/classificacao_equipes.js?v=6.877"></script>
 </html>

--- a/src/main/webapp/html5/classificacao_geral.html
+++ b/src/main/webapp/html5/classificacao_geral.html
@@ -5,8 +5,8 @@
 <meta name="viewport"
 	content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 <link rel="stylesheet" href="../bootstrap/css/bootstrap.min.css">
-<link rel="stylesheet" href="css/flmane.css?v=6.854">
-<link rel="stylesheet" href="css/mdb-btns.css?v=6.854">
+<link rel="stylesheet" href="css/flmane.css?v=6.877">
+<link rel="stylesheet" href="css/mdb-btns.css?v=6.877">
 <script src="../jquery/jquery-3.2.1.min.js"></script>
 <script src="../bootstrap/js/bootstrap.min.js"></script>
 
@@ -15,7 +15,7 @@
 <body class="body">
 <div id="f1body">
 	<section id="head" class="container" style="margin: 10px;">
-        <a href="classificacao.html?v=6.854" id="voltar" class="voltar black">
+        <a href="classificacao.html?v=6.877" id="voltar" class="voltar black">
           <span class="glyphicon glyphicon glyphicon-chevron-left" aria-hidden="true"></span> 
         </a>
 		<h3 style="display: inline;">Fl-Mane</h3>
@@ -37,13 +37,13 @@
 	</section>
 	<footer class="footer">
 		<div class="container">
-			<p>Build: 6.854</p>
+			<p>Build: 6.877</p>
 		</div>
 	</footer>
 </div>	
 </body>
-<script src="js/util.js?v=6.854"></script>
-<script src="js/loader.js?v=6.854"></script>
-<script src="js/lang.js?v=6.854"></script>
-<script src="js/classificacao_geral.js?v=6.854"></script>
+<script src="js/util.js?v=6.877"></script>
+<script src="js/loader.js?v=6.877"></script>
+<script src="js/lang.js?v=6.877"></script>
+<script src="js/classificacao_geral.js?v=6.877"></script>
 </html>

--- a/src/main/webapp/html5/classificacao_temporada.html
+++ b/src/main/webapp/html5/classificacao_temporada.html
@@ -5,8 +5,8 @@
 <meta name="viewport"
 	content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 <link rel="stylesheet" href="../bootstrap/css/bootstrap.min.css">
-<link rel="stylesheet" href="css/flmane.css?v=6.854">
-<link rel="stylesheet" href="css/mdb-btns.css?v=6.854">
+<link rel="stylesheet" href="css/flmane.css?v=6.877">
+<link rel="stylesheet" href="css/mdb-btns.css?v=6.877">
 <script src="../jquery/jquery-3.2.1.min.js"></script>
 <script src="../bootstrap/js/bootstrap.min.js"></script>
 
@@ -15,7 +15,7 @@
 <body class="body">
 <div id="f1body">
 	<section id="head" class="container" style="margin: 10px;">
-        <a href="classificacao.html?v=6.854" id="voltar" class="voltar black">
+        <a href="classificacao.html?v=6.877" id="voltar" class="voltar black">
           <span class="glyphicon glyphicon glyphicon-chevron-left" aria-hidden="true"></span> 
         </a>
 		<h3 style="display: inline;">Fl-Mane</h3>
@@ -57,13 +57,13 @@
 	</section>
 	<footer class="footer">
 		<div class="container">
-			<p>Build: 6.854</p>
+			<p>Build: 6.877</p>
 		</div>
 	</footer>
 </div>	
 </body>
-<script src="js/util.js?v=6.854"></script>
-<script src="js/loader.js?v=6.854"></script>
-<script src="js/lang.js?v=6.854"></script>
-<script src="js/classificacao_temporada.js?v=6.854"></script>
+<script src="js/util.js?v=6.877"></script>
+<script src="js/loader.js?v=6.877"></script>
+<script src="js/lang.js?v=6.877"></script>
+<script src="js/classificacao_temporada.js?v=6.877"></script>
 </html>

--- a/src/main/webapp/html5/configuracao.html
+++ b/src/main/webapp/html5/configuracao.html
@@ -5,15 +5,15 @@
 <meta name="viewport"
 	content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 <link rel="stylesheet" href="../bootstrap/css/bootstrap.min.css">
-<link rel="stylesheet" href="css/flmane.css?v=6.854">
-<link rel="stylesheet" href="css/mdb-btns.css?v=6.854">
+<link rel="stylesheet" href="css/flmane.css?v=6.877">
+<link rel="stylesheet" href="css/mdb-btns.css?v=6.877">
 <script src="../jquery/jquery-3.2.1.min.js"></script>
 <title>Fl-Mane</title>
 </head>
 <body class="body">
 	<div id="f1body">
 		<section id="head" class="container" style="margin: 10px;">
-			<a href="index.html?v=6.854" class="voltar black"> <span
+			<a href="index.html?v=6.877" class="voltar black"> <span
 				class="glyphicon glyphicon glyphicon-chevron-left"
 				aria-hidden="true"></span>
 			</a>
@@ -42,16 +42,16 @@
 		</section>
 		<footer class="footer">
 			<div class="container">
-				<p>Build: 6.854</p>
-				<input id="versao" type="hidden" value="6.854" />
+				<p>Build: 6.877</p>
+				<input id="versao" type="hidden" value="6.877" />
 			</div>
 		</footer>
 	</div>
 </body>
-<script src="js/util.js?v=6.854"></script>
-<script src="js/loader.js?v=6.854"></script>
-<script src="js/lang.js?v=6.854"></script>
-<script src="js/tela.js?v=6.854"></script>
+<script src="js/util.js?v=6.877"></script>
+<script src="js/loader.js?v=6.877"></script>
+<script src="js/lang.js?v=6.877"></script>
+<script src="js/tela.js?v=6.877"></script>
 <script>
 	//Ripple-effect animation
 	(function($) {

--- a/src/main/webapp/html5/controles.html
+++ b/src/main/webapp/html5/controles.html
@@ -5,7 +5,7 @@
 <meta name="viewport"
 	content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 <link rel="stylesheet" href="../bootstrap/css/bootstrap.min.css">
-<link rel="stylesheet" href="css/flmane.css?v=6.854">
+<link rel="stylesheet" href="css/flmane.css?v=6.877">
 <script src="../jquery/jquery-3.2.1.min.js"></script>
 <script src="../bootstrap/js/bootstrap.min.js"></script>
 
@@ -14,7 +14,7 @@
 <body class="body">
 	<div id="f1body">
 		<section id="head" class="container" style="margin: 10px;">
-			<a href="index.html?v=6.854" class="voltar black"> <span
+			<a href="index.html?v=6.877" class="voltar black"> <span
 				class="glyphicon glyphicon glyphicon-chevron-left"
 				aria-hidden="true"></span>
 			</a>
@@ -83,14 +83,14 @@
 		</section>
 		<footer class="footer">
 			<div class="container">
-				<p>Build: 6.854</p>
+				<p>Build: 6.877</p>
 			</div>
 		</footer>
 	</div>
 </body>
-<script src="js/util.js?v=6.854"></script>
-<script src="js/loader.js?v=6.854"></script>
-<script src="js/lang.js?v=6.854"></script>
+<script src="js/util.js?v=6.877"></script>
+<script src="js/loader.js?v=6.877"></script>
+<script src="js/lang.js?v=6.877"></script>
 <script>
 $('#TIPO_PNEU_MOLE').html(lang_text('TIPO_PNEU_MOLE'));
 $('#TIPO_PNEU_DURO').html(lang_text('TIPO_PNEU_DURO'));

--- a/src/main/webapp/html5/corrida.html
+++ b/src/main/webapp/html5/corrida.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, maximum-scale=1, user-scalable=no">
 <script src="../jquery/jquery-3.2.1.min.js"></script>
-<link rel="stylesheet" href="css/flmane.css?v=6.854">
+<link rel="stylesheet" href="css/flmane.css?v=6.877">
 </head>
 <body id="body" style="width: 100%; height: 100%; margin: 0px; overflow: hidden" class="body">
 <canvas id="maneCanvas"></canvas>
@@ -12,13 +12,13 @@
 <img id="imgJog1" class="userPic"/>
 <img id="imgJog2" class="userPic"/>
 </body>
-<script src="js/util.js?v=6.854"></script>
-<script src="js/lang.js?v=6.854"></script>
-<script src="js/geo.js?v=6.854"></script>
-<script src="js/fps.js?v=6.854"></script>
-<script src="js/vdp.js?v=6.854"></script>
-<script src="js/ctl.js?v=6.854"></script>
-<script src="js/rest.js?v=6.854"></script>
-<script src="js/mid.js?v=6.854"></script>
-<script src="js/cpu.js?v=6.854"></script>
+<script src="js/util.js?v=6.877"></script>
+<script src="js/lang.js?v=6.877"></script>
+<script src="js/geo.js?v=6.877"></script>
+<script src="js/fps.js?v=6.877"></script>
+<script src="js/vdp.js?v=6.877"></script>
+<script src="js/ctl.js?v=6.877"></script>
+<script src="js/rest.js?v=6.877"></script>
+<script src="js/mid.js?v=6.877"></script>
+<script src="js/cpu.js?v=6.877"></script>
 </html>

--- a/src/main/webapp/html5/equipe.html
+++ b/src/main/webapp/html5/equipe.html
@@ -5,7 +5,7 @@
 <meta name="viewport"
 	content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 <link rel="stylesheet" href="../bootstrap/css/bootstrap.min.css">
-<link rel="stylesheet" href="css/flmane.css?v=6.854">
+<link rel="stylesheet" href="css/flmane.css?v=6.877">
 <script src="../jquery/jquery-3.2.1.min.js"></script>
 <script src="../bootstrap/js/bootstrap.min.js"></script>
 
@@ -14,7 +14,7 @@
 <body class="body">
 	<div id="f1body">
 		<section id="head" class="container" style="margin: 10px;">
-			<a href="index.html?v=6.854" id="voltar" class="voltar black"> <span
+			<a href="index.html?v=6.877" id="voltar" class="voltar black"> <span
 				class="glyphicon glyphicon glyphicon-chevron-left"
 				aria-hidden="true"></span>
 			</a>
@@ -189,13 +189,13 @@
 		</section>
 		<footer class="footer">
 			<div class="container">
-				<p>Build: 6.854</p>
+				<p>Build: 6.877</p>
 			</div>
 		</footer>
 	</div>
 </body>
-<script src="js/util.js?v=6.854"></script>
-<script src="js/loader.js?v=6.854"></script>
-<script src="js/lang.js?v=6.854"></script>
-<script src="js/equipe.js?v=6.854"></script>
+<script src="js/util.js?v=6.877"></script>
+<script src="js/loader.js?v=6.877"></script>
+<script src="js/lang.js?v=6.877"></script>
+<script src="js/equipe.js?v=6.877"></script>
 </html>

--- a/src/main/webapp/html5/index.html
+++ b/src/main/webapp/html5/index.html
@@ -4,8 +4,8 @@
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 	<link rel="stylesheet" href="../bootstrap/css/bootstrap.min.css">
-	<link rel="stylesheet" href="css/flmane.css?v=6.854">
-	<link rel="stylesheet" href="css/mdb-btns.css?v=6.854">
+	<link rel="stylesheet" href="css/flmane.css?v=6.877">
+	<link rel="stylesheet" href="css/mdb-btns.css?v=6.877">
 	<script src="../jquery/jquery-3.2.1.min.js"></script>
 	<script src="../jwtdecode/jwt-decode.js"></script>
 	<!--  <script src="https://accounts.google.com/gsi/client" async defer></script> -->
@@ -43,14 +43,14 @@
 						maxlength="30"
 				/>
 			</div>
-			<a href="jogar.html?v=6.854" class="list-group-item transparent">
+			<a href="jogar.html?v=6.877" class="list-group-item transparent">
 				<button type="button" id="btnJogar" class="btn btn-default btn-block btn-raised bgTransparent"></button>
 			</a>
-			<a href="classificacao.html?v=6.854" class="list-group-item transparent">
+			<a href="classificacao.html?v=6.877" class="list-group-item transparent">
 				<button type="button" id="btnClassificacao"
 						class="btn btn-default btn-block btn-raised bgTransparent"></button>
 			</a>
-			<a href="equipe.html?v=6.854" class="list-group-item transparent ">
+			<a href="equipe.html?v=6.877" class="list-group-item transparent ">
 				<button type="button" id="btnEquipe"
 						class="btn btn-default btn-block btn-raised bgTransparent"></button>
 			</a>
@@ -58,11 +58,11 @@
 				<button type="button" id="btnCampeonato"
 						class="btn btn-default btn-block btn-raised bgTransparent"></button>
 			</a>
-			<a href="controles.html?v=6.854" class="list-group-item transparent">
+			<a href="controles.html?v=6.877" class="list-group-item transparent">
 				<button type="button" id="btnControles"
 						class="btn btn-default btn-block btn-raised bgTransparent"></button>
 			</a>
-			<a href="configuracao.html?v=6.854" class="list-group-item transparent">
+			<a href="configuracao.html?v=6.877" class="list-group-item transparent">
 				<button type="button" id="btnConfiguracao"
 						class="btn btn-default btn-block btn-raised bgTransparent"></button>
 			</a>
@@ -77,14 +77,14 @@
 	</section>
 	<footer class="footer">
 		<div class="container">
-			<p>Build: 6.854</p>
-			<input id="versao" type="hidden" value="6.854"/>
+			<p>Build: 6.877</p>
+			<input id="versao" type="hidden" value="6.877"/>
 		</div>
 	</footer>
 </div>
 </body>
-<script src="js/util.js?v=6.854"></script>
-<script src="js/loader.js?v=6.854"></script>
-<script src="js/lang.js?v=6.854"></script>
-<script src="js/index.js?v=6.854"></script>
+<script src="js/util.js?v=6.877"></script>
+<script src="js/loader.js?v=6.877"></script>
+<script src="js/lang.js?v=6.877"></script>
+<script src="js/index.js?v=6.877"></script>
 </html>

--- a/src/main/webapp/html5/jogar.html
+++ b/src/main/webapp/html5/jogar.html
@@ -5,7 +5,7 @@
 <meta name="viewport"
 	content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 <link rel="stylesheet" href="../bootstrap/css/bootstrap.min.css">
-<link rel="stylesheet" href="css/flmane.css?v=6.854">
+<link rel="stylesheet" href="css/flmane.css?v=6.877">
 <script src="../jquery/jquery-3.2.1.min.js"></script>
 <script src="../bootstrap/js/bootstrap.min.js"></script>
 
@@ -14,7 +14,7 @@
 <body class="body">
 <div id="f1body">
 	<section id="head" class="container" style="margin: 10px;">
-        <a href="index.html?v=6.854" id="voltar" class="voltar black">
+        <a href="index.html?v=6.877" id="voltar" class="voltar black">
           <span class="glyphicon glyphicon glyphicon-chevron-left" aria-hidden="true"></span> 
         </a>
 		<h3 style="display: inline;">Fl-Mane</h3>
@@ -193,13 +193,13 @@
 	</section>
 	<footer class="footer">
 		<div class="container">
-			<p>Build: 6.854</p>
+			<p>Build: 6.877</p>
 		</div>
 	</footer>
 </div>	
 </body>
-<script src="js/util.js?v=6.854"></script>
-<script src="js/loader.js?v=6.854"></script>
-<script src="js/lang.js?v=6.854"></script>
-<script src="js/jogar.js?v=6.854"></script>
+<script src="js/util.js?v=6.877"></script>
+<script src="js/loader.js?v=6.877"></script>
+<script src="js/lang.js?v=6.877"></script>
+<script src="js/jogar.js?v=6.877"></script>
 </html>

--- a/src/main/webapp/html5/js/vdp.js
+++ b/src/main/webapp/html5/js/vdp.js
@@ -77,9 +77,9 @@ var funqueue = [];
 var fps;
 
 // Constantes de atualização suave
-var SUAVE_MULT_RETA = 3;
-var SUAVE_MULT_CURVA_ALTA = 2.5;
-var SUAVE_MULT_CURVA_BAIXA = 2;
+var SUAVE_MULT_RETA = 2.7;
+var SUAVE_MULT_CURVA_ALTA = 2.3;
+var SUAVE_MULT_CURVA_BAIXA = 1.7;
 var SUAVE_INC_ACEL = 1;
 
 function vdp_desenha(fps_p) {

--- a/src/main/webapp/html5/resultado.html
+++ b/src/main/webapp/html5/resultado.html
@@ -10,7 +10,7 @@
 </head>
 <body class="body">
 	<section id="head" class="container" style="margin: 10px;">
-        <a href="index.html?v=6.854" class="voltar black">
+        <a href="index.html?v=6.877" class="voltar black">
           <span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span> 
         </a>
 		<h3 style="display: inline;">Fl-Mane</h3>
@@ -86,12 +86,12 @@
 	</section>
 	<footer class="footer">
 		<div class="container">
-			<p >Build: 6.854</p>
+			<p >Build: 6.877</p>
 		</div>
 	</footer>
 </body>
-<script src="js/loader.js?v=6.854"></script>
-<script src="js/util.js?v=6.854"></script>
-<script src="js/lang.js?v=6.854"></script>
-<script src="js/resultado.js?v=6.854"></script>
+<script src="js/loader.js?v=6.877"></script>
+<script src="js/util.js?v=6.877"></script>
+<script src="js/lang.js?v=6.877"></script>
+<script src="js/resultado.js?v=6.877"></script>
 </html>


### PR DESCRIPTION
… Hibernate 7

- pom.xml: Java 21, Tomcat 11, jakarta.servlet-api 6.1, Jersey 4.0.2, Hibernate 7.4 (org.hibernate.orm)
- Migração completa javax.* → jakarta.* (servlet, ws.rs, persistence)
- ControlePersistencia: 24 métodos Criteria API → HQL tipado; saveOrUpdate → merge
- ControleClassificacao: Criteria → HQL; saveOrUpdate → merge; fix duplicata de corrida (CascadeType.ALL)
- ServletPaddock: SchemaExport → Persistence.generateSchema; javax strings → jakarta
- persistence.xml: namespace Jakarta 3.2; entidades explícitas; IDENTITY generation
- LetsRace: corrige endpoints campeonato passando token onde esperava idUsuario
- ControleCampeonatoServidor: default nivel=CONTROLE_AUTOMATICO quando nulo
- FormatNumber/Util/Numero: deprecações wrapper constructor → valueOf/parseX
- TestePista: remove finalize() depreciado