### PR TITLE
feature/testes_unitarios: adiciona suíte de testes unitários (124 tes…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Build & Run
 
 ```bash
+# Rodar a suíte de testes unitários (JUnit 5 + Mockito)
+mvn test
+
 # Fat jar com H2 (desenvolvimento local)
 mvn clean package -Ph2 -DskipTests
 

--- a/openspec/changes/archive/2026-06-30-add-unit-tests/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-30-add-unit-tests/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-30

--- a/openspec/changes/archive/2026-06-30-add-unit-tests/design.md
+++ b/openspec/changes/archive/2026-06-30-add-unit-tests/design.md
@@ -1,0 +1,78 @@
+## Context
+
+`pom.xml` hoje não tem nenhuma dependência de teste e não existe `src/test/java`. Os comandos de build documentados em `CLAUDE.md` (`mvn clean package -Ph2 -DskipTests`) sempre pulam testes — não por terem sido desabilitados de propósito, mas porque nunca existiram. A verificação de regressão é 100% manual (rodar o jogo, ou `./simulacao.sh` para corridas headless).
+
+`LetsRace` (`br.f1mane.servidor.rest.LetsRace`) é o único recurso JAX-RS do projeto (`@Path("/letsRace")`, registrado via scan de pacote em `web.xml` → `jersey.config.server.provider.packages=br.f1mane.servidor.rest`), com 38 métodos de endpoint. Hoje ela não tem construtor explícito: os campos `controlePaddock` e `carregadorRecursos` são inicializados inline a partir de singletons estáticos (`PaddockServer.getControlePaddock()`, `CarregadorRecursos.getCarregadorRecursos(false)`). `PaddockServer.getControlePaddock()` por sua vez chama `PaddockServer.init(null)`, que constrói um `ControlePaddockServidor` real (com `ControlePersistencia`/Hibernate por trás) e **sobe uma thread** (`MonitorAtividade`). Isso significa que, do jeito que está, não dá pra instanciar `LetsRace` em teste sem acionar esse grafo inteiro — exatamente o mesmo problema de acoplamento já mapeado para `ControleSafetyCar`/`ControleCorrida`, só que aqui ele bloqueia 100% da camada REST, não só uma classe.
+
+A maior parte da lógica de `LetsRace` é fina (extrai header/path param → chama um método do `ControlePaddockServidor` ou `ControleJogosServer` → embrulha o retorno num `Response`), mas o mapeamento desse retorno para status HTTP tem ramificação real e foi a causa direta de bug nesta sessão: `processsaMensagem(Object, String)` decide 400 (`MsgSrv`) vs 500 (`ErroServ`) vs `null` (sucesso, segue o fluxo normal), e cada endpoint individualmente decide 401 (sessão inválida via `obterSessaoPorToken`), 403 (`sessaoCliente.isGuest()`), 204 (resultado vazio) ou 200. Essa é a lógica que mais vale a pena travar com teste — é onde já vazou bug pra produção, e é pequena/determinística o suficiente para testar sem mocks pesados, desde que `ControlePaddockServidor`/`ControleJogosServer` em si sejam mockáveis (ambos são classes concretas, não-`final`, com métodos não-`final` — `Mockito.mock()` padrão funciona sem precisar de `mockito-inline`).
+
+Já `br.nnpe.Util` (utilitários) é uma classe de funções estáticas sem dependência de UI, thread ou I/O — candidata de baixo custo, mantida como segunda prioridade desta mudança.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Ter `mvn test` funcionando e rodando testes reais no CI/dev (mesmo que o build de produção continue usando `-DskipTests`).
+- Tornar `LetsRace` instanciável em teste sem subir o grafo real do servidor (Hibernate, threads), via injeção de dependência mínima.
+- Cobrir com teste unitário todo endpoint de `LetsRace`: delegação correta de parâmetros para `ControlePaddockServidor`/`ControleJogosServer` (mockados) e o mapeamento de retorno para status HTTP (200/204/400/401/403/500), incluindo o caminho `processsaMensagem` que causou o bug de `criarSessaoNome` corrigido nesta sessão.
+- Cobrir com teste unitário a lógica de pontos de carreira (`Util.processaValorPontosCarreira`) — a fonte do bug de pontos infinitos já corrigido, hoje sem nenhuma rede de proteção contra regressão.
+- Estabelecer o padrão de onde/como escrever testes futuros (estrutura de pastas, framework, convenção de nomes) para que o restante do motor de jogo possa ganhar cobertura incrementalmente.
+
+**Non-Goals:**
+- Testar o conteúdo de negócio dentro de `ControlePaddockServidor`/`ControleJogosServer` (ex.: regra exata de criação de sessão, cálculo de classificação) — esses são mockados nos testes de `LetsRace`; testá-los de verdade é trabalho futuro, com o mesmo padrão de injeção de dependência se necessário.
+- Testes de integração ponta-a-ponta (subir Tomcat embutido, requisição HTTP real) — fora de escopo; o foco é teste unitário chamando os métodos Java de `LetsRace` diretamente.
+- Cobertura do motor de jogo local (`ControleCorrida`, `ControleSafetyCar`, rendering) nesta mudança — fica como follow-up, sem compromisso de spec aqui.
+- Refatoração ampla de `LetsRace` ou dos controllers — a única mudança de produção é a adição de um construtor secundário em `LetsRace` para injeção; nenhum endpoint muda de comportamento.
+
+## Decisions
+
+- **JUnit 5 + Mockito**, escopados como `<scope>test</scope>` no `pom.xml`, ativos apenas no profile `test` já existente (que hoje só inclui `logback-test.xml`). Alternativa considerada: TestNG — descartada por não trazer vantagem aqui e por JUnit 5 ser o padrão de fato no ecossistema Java/Maven atual.
+- **`maven-surefire-plugin`** explicitado no `pom.xml` (hoje ausente) fixando uma versão compatível com Java 21 e JUnit 5 (`junit-platform`), para que `mvn test` funcione de forma determinística.
+- **Construtor pacote-privado em `LetsRace`** para injeção de teste:
+  ```java
+  public LetsRace() {
+      this(CarregadorRecursos.getCarregadorRecursos(false), PaddockServer.getControlePaddock());
+  }
+  LetsRace(CarregadorRecursos carregadorRecursos, ControlePaddockServidor controlePaddock) {
+      this.carregadorRecursos = carregadorRecursos;
+      this.controlePaddock = controlePaddock;
+  }
+  ```
+  O construtor público sem argumentos é o que o Jersey usa via scan de pacote (precisa continuar existindo e se comportando igual); o construtor pacote-privado é usado só pelos testes (mesmo pacote `br.f1mane.servidor.rest`), injetando `ControlePaddockServidor` mockado. Alternativa considerada: reflection para sobrescrever o campo `controlePaddock` em teste — descartada por ser mais frágil e menos legível que um construtor explícito; um segundo construtor é o padrão usual para recursos JAX-RS testáveis.
+- **`ControleJogosServer` também mockado** (não instanciado de verdade): como ele é obtido via `controlePaddock.getControleJogosServer()`, basta o mock de `ControlePaddockServidor` retornar um mock de `ControleJogosServer` em `when(...)`.
+- **Estrutura espelhada**: `src/test/java/br/f1mane/servidor/rest/LetsRaceTest.java`, `src/test/java/br/nnpe/UtilTest.java` — convenção Maven padrão, zero configuração extra de `testSourceDirectory`.
+- **Build de produção inalterado**: `-DskipTests` continua nos comandos documentados de `mvn package`. `mvn test` passa a ser o comando para rodar a suíte explicitamente.
+
+## Risks / Trade-offs
+
+- [O construtor pacote-privado é uma mudança em código de produção, mesmo que pequena] → Mitigação: o construtor público (usado pelo Jersey em runtime) delega para o novo construtor com exatamente os mesmos valores que os field initializers atuais produziam — comportamento de produção idêntico, validado rodando o jar empacotado depois da mudança.
+- [38 endpoints é uma superfície grande; cobrir todos com o mesmo nível de detalhe pode ser desproporcional] → Mitigação: priorizar os endpoints que (a) têm ramificação de status HTTP (401/403/400/500/204) e (b) já causaram bug real (`criarSessaoNome`, `processsaMensagem`); endpoints que só repassam um valor sem decisão (ex.: `verificaServico`) recebem um teste simples de delegação, não uma suíte extensa.
+- [Versão do `maven-surefire-plugin` incompatível com o `maven.compiler.release=21` já usado] → Mitigação: usar a mesma versão major já validada para Java 21 (Surefire 3.x), testada localmente antes de finalizar a tarefa.
+
+## Migration Plan
+
+1. Adicionar dependências de teste e plugin do Surefire ao `pom.xml`.
+2. Adicionar o construtor pacote-privado em `LetsRace` (sem alterar o construtor público).
+3. Criar `src/test/java/br/f1mane/servidor/rest/LetsRaceTest.java` cobrindo autenticação/autorização, `processsaMensagem` e os endpoints de maior risco.
+4. Criar `src/test/java/br/nnpe/UtilTest.java` cobrindo a tabela de custo/refund de pontos.
+5. Rodar `mvn test` e confirmar que passa; rodar `mvn clean package -Ph2 -DskipTests` e confirmar que o jar gerado continua idêntico em comportamento.
+6. Atualizar `CLAUDE.md` com o comando `mvn test`.
+
+Não há rollback de dados ou produção envolvido — é só adição de testes, dependências de escopo `test`, e um construtor adicional não-destrutivo.
+
+## Open Questions
+
+- Vale a pena, numa próxima mudança, aplicar o mesmo padrão de injeção de dependência a `ControlePaddockServidor`/`ControleJogosServer` para testar a lógica de negócio real (não só a camada REST mockada)? **Resolvido**: não é necessário — ver decisão abaixo, essas classes já são construtor-injetadas.
+
+## Decisão adicional: cobertura de `br.f1mane.servidor.controles`
+
+Diferente de `LetsRace`, as 5 classes do pacote já recebem suas dependências via construtor: `ControleCampeonatoServidor(ControlePersistencia, ControlePaddockServidor)`, `ControleClassificacao(ControlePersistencia, ControleCampeonatoServidor)`, `ControleJogosServer(DadosPaddock, ControleClassificacao, ControleCampeonatoServidor, ControlePersistencia, ControlePaddockServidor)`, `ControlePaddockServidor(ControlePersistencia)`. `ControlePersistencia` em si não é `final`, seus métodos (`getSession()`, `carregaCarreiraJogador`, `existeNomeCarro`, `gravarDados`, etc.) também não são `final` — mockável direto com `Mockito.mock(ControlePersistencia.class)`. **Nenhuma mudança de produção é necessária** para tornar essas 5 classes testáveis.
+
+**Atualização**: `ControleClassificacao`, `ControleCampeonatoServidor` e `ControlePaddockServidor` tinham um campo `carregadorRecursos` inicializado inline via `CarregadorRecursos.getCarregadorRecursos(false)` (não injetado), igual ao problema original de `LetsRace` antes do refactor. Isso foi corrigido com o mesmo padrão de `LetsRace`: cada uma das 3 classes ganhou um construtor pacote-privado extra recebendo `CarregadorRecursos`, com o construtor público delegando para ele com o valor real (`CarregadorRecursos.getCarregadorRecursos(false)`) — comportamento de produção idêntico. `ControlePaddockServidor` repassa o `CarregadorRecursos` injetado para as instâncias internas de `ControleCampeonatoServidor`/`ControleClassificacao` que ele mesmo constrói, então o grafo inteiro compartilha a mesma instância (real ou mock). Isso desbloqueou teste das validações de livery/capacete em `atualizaCarreira` e do caminho de sucesso completo de `criarCampeonato` (que dependia de `carregarTemporadasPilotosDefauts()`).
+
+Critério de priorização por classe (do mesmo jeito que em `LetsRace`): cobrir métodos com ramificação de regra de negócio real; pular getters/setters e delegações de uma linha sem decisão.
+
+- `ControleClassificacao`: `gerarPontos` (tabela de pontos por posição — pura, zero mock), `validadeDistribuicaoPontos`/`redistribuiPontos` (static, orquestra `Util.processaValorPontosCarreira` — sequência direta do bug de `f47e7a74`), `atualizaCarreira` (validação de nome/tamanho/duplicidade, mock de `ControlePersistencia`).
+- `ControleCampeonatoServidor`: `criarCampeonato`/`finalizaCampeonato` (validação de sessão nula, regras de ciclo de vida).
+- `ControlePaddockServidor`: `criarSessaoNome`/`criarSessaoGoogle`/`criarSessaoVisitante`/`obterSessaoPorToken` (a mesma lógica que `LetsRaceTest` hoje só vê mockada).
+- `ControleJogosServer`: `mudarGiroMotor`, `mudarAgressividadePiloto`, `mudarTracadoPiloto`, `mudarDrs`, `mudarErs`, `boxPiloto` — validação de piloto/sessão antes de aplicar a mudança.
+- `ControlePersistencia`: `getSession()` (branch `Global.DATABASE`) — cobertura mais rasa, é majoritariamente wrapper de CRUD do Hibernate.

--- a/openspec/changes/archive/2026-06-30-add-unit-tests/proposal.md
+++ b/openspec/changes/archive/2026-06-30-add-unit-tests/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+O projeto não tem nenhum teste automatizado (`src/test` não existe, sem JUnit/Mockito no `pom.xml`). Toda verificação hoje é manual. Isso já causou regressão real: o bug de "pontos infinitos no nível 999" (commit `f47e7a74`) ficou em produção até alguém notar manualmente. Na mesma sessão de hoje, dois bugs distintos passaram batido exatamente pela porta de entrada do multiplayer — a classe REST `LetsRace`: `criarSessaoNome` retornava 400 sem nenhuma mensagem útil porque `ErroServ` não serializava em JSON, e a causa raiz (schema/JDBC mal configurado) só apareceu ao ler o log do servidor manualmente. `LetsRace` é o único ponto de entrada HTTP de todo o modo multiplayer (38 endpoints) — autenticação, criação de sessão, carregamento de circuito, jogo em corrida, campeonato, imagens. Qualquer regressão de mapeamento de erro (401/403/400/500) ou de delegação incorreta para `ControlePaddockServidor`/`ControleJogosServer` quebra o jogo pra todo cliente web, e hoje não há nenhuma rede de proteção.
+
+## What Changes
+
+- Adiciona JUnit 5 + Mockito como dependência de teste no `pom.xml`, escopada ao profile `test`, sem afetar o jar de produção.
+- Cria a estrutura `src/test/java` espelhando os pacotes de `src/main/java`, com `maven-surefire-plugin` configurado para `mvn test` (hoje os builds documentados usam `-DskipTests`, então testes nunca rodam).
+- **Foco principal**: testes unitários de `LetsRace` (`br.f1mane.servidor.rest.LetsRace`) cobrindo todo endpoint que delega para `ControlePaddockServidor`/`ControleJogosServer`, incluindo:
+  - mapeamento de sessão inválida → 401, visitante em endpoint restrito a equipe → 403;
+  - mapeamento de `ErroServ` → 500 e `MsgSrv` → 400 feito por `processsaMensagem` (o ponto exato que causou o bug de hoje);
+  - delegação correta de parâmetros de path/header/query para o método certo do controller (giro de motor, agressividade, DRS, ERS, traçado, box, criar sessão por nome/Google/visitante, jogar, jogar campeonato, equipe, campeonato).
+  - **BREAKING (interno, não de API)**: `LetsRace` ganha um construtor pacote-privado para injeção de dependências (`ControlePaddockServidor`, `CarregadorRecursos`) usado pelos testes; o construtor público sem argumentos usado pelo Jersey continua existindo e se comporta exatamente como hoje.
+- Segundo plano (já coberto por infraestrutura, menor prioridade): `Util.processaValorPontosCarreira`, a função de cálculo de pontos de carreira responsável pelo bug do commit `f47e7a74`.
+- Documenta no `CLAUDE.md` o comando `mvn test` como parte do fluxo de build.
+
+- **Incremento de escopo**: cobertura de teste unitário das 5 classes de `br.f1mane.servidor.controles` (`ControlePaddockServidor`, `ControleJogosServer`, `ControleClassificacao`, `ControleCampeonatoServidor`, `ControlePersistencia`) — a lógica de negócio real que `LetsRaceTest` hoje só exercita via mock. Diferente de `LetsRace`, essas 5 classes já usam injeção de dependência via construtor (`ControlePersistencia` é passado explicitamente por todas elas) — **nenhum refactor de produção é necessário** para torná-las testáveis, só mockar `ControlePersistencia`/`Session` do Hibernate.
+  - Prioridade por densidade de regra de negócio: `ControleClassificacao` (pontuação, validação de distribuição de pontos — sequência direta de `UtilTest`/`Util.processaValorPontosCarreira`) e `ControleCampeonatoServidor` (ciclo de vida de campeonato) primeiro; depois `ControlePaddockServidor` (sessão/autenticação) e `ControleJogosServer` (controles de pilotagem); `ControlePersistencia` por último, com cobertura mais rasa por ser majoritariamente wrapper de CRUD do Hibernate sem ramificação de regra.
+  - Getters/setters triviais e delegações de uma linha sem decisão não SHALL receber teste dedicado — mesmo critério já usado em `LetsRaceTest`.
+
+## Capabilities
+
+### New Capabilities
+- `unit-testing-infra`: padrão e infraestrutura de testes unitários do projeto — onde os testes vivem, qual framework, como rodam no build.
+- `letsrace-endpoint-tests`: cobertura de teste unitário da camada REST `LetsRace` — autenticação/autorização, mapeamento de erro para status HTTP, e delegação correta para os controllers de jogo.
+- `controles-business-logic-tests`: cobertura de teste unitário da lógica de negócio real nas 5 classes de `br.f1mane.servidor.controles`, com `ControlePersistencia`/`Session` mockados.
+
+## Impact
+
+- `pom.xml`: novas dependências de teste (JUnit 5, Mockito) e configuração do `maven-surefire-plugin`.
+- Novo diretório `src/test/java/...` (sem impacto no jar `-Ph2`/`-Pmysql`, já que testes não entram no fat jar).
+- `LetsRace.java`: adiciona um segundo construtor (pacote-privado) para permitir injetar `ControlePaddockServidor`/`CarregadorRecursos` mockados em teste, sem alterar o comportamento do construtor público usado pelo Jersey.
+- `br.f1mane.servidor.controles.*`: nenhuma mudança de produção — só testes novos, usando os construtores já existentes.
+- `CLAUDE.md`: adiciona `mvn test` à seção de Build & Run.

--- a/openspec/changes/archive/2026-06-30-add-unit-tests/specs/controles-business-logic-tests/spec.md
+++ b/openspec/changes/archive/2026-06-30-add-unit-tests/specs/controles-business-logic-tests/spec.md
@@ -1,0 +1,74 @@
+## ADDED Requirements
+
+### Requirement: As classes de br.f1mane.servidor.controles SHALL ser testáveis sem mudança de produção
+Testes unitários das classes `ControlePaddockServidor`, `ControleJogosServer`, `ControleClassificacao`, `ControleCampeonatoServidor` e `ControlePersistencia` SHALL usar os construtores já existentes dessas classes, mockando `ControlePersistencia` (e `org.hibernate.Session`/`Transaction` quando necessário) via Mockito. Nenhum construtor novo ou mudança de visibilidade SHALL ser necessária nessas 5 classes.
+
+#### Scenario: ControleClassificacao é testável mockando apenas ControlePersistencia
+- **WHEN** um teste cria `new ControleClassificacao(controlePersistenciaMock, controleCampeonatoServidorMock)`
+- **THEN** nenhuma conexão de banco real é acionada
+
+### Requirement: A tabela de pontos por posição SHALL ter cobertura de teste
+`ControleClassificacao.gerarPontos(Piloto)` SHALL retornar os pontos corretos conforme a tabela de pontuação por posição de chegada (1º:25, 2º:18, 3º:15, 4º:12, 5º:10, 6º:8, 7º:6, 8º:4, 9º:2, 10º:1, 11º em diante:0).
+
+#### Scenario: Posições de pontuação retornam o valor correto
+- **WHEN** `gerarPontos(piloto)` é chamado com `piloto.getPosicao()` igual a cada uma das posições 1 a 10
+- **THEN** o retorno corresponde exatamente ao valor da tabela de pontos por posição
+
+#### Scenario: Posição fora do pódio de pontos retorna zero
+- **WHEN** `gerarPontos(piloto)` é chamado com `piloto.getPosicao()` igual a 11 ou maior
+- **THEN** o retorno é 0
+
+### Requirement: A validação de redistribuição de pontos SHALL ter cobertura de teste
+`ControleClassificacao.validadeDistribuicaoPontos` (que orquestra `Util.processaValorPontosCarreira` por atributo) SHALL calcular corretamente o saldo de pontos de construtores ao mudar múltiplos atributos (aerodinâmica, carro, freio, piloto) simultaneamente, incluindo o caso de regressão do bug de pontos infinitos no nível 999.
+
+#### Scenario: Upgrade de um único atributo debita o custo correto
+- **WHEN** `validadeDistribuicaoPontos` é chamado com um único atributo subindo de nível dentro da mesma faixa de custo
+- **THEN** o saldo retornado é igual ao saldo base menos o custo daquele atributo
+
+#### Scenario: Mudança simultânea em múltiplos atributos soma os custos/refunds corretamente
+- **WHEN** `validadeDistribuicaoPontos` é chamado com dois atributos subindo e um descendo ao mesmo tempo
+- **THEN** o saldo retornado reflete a soma de todos os débitos e créditos individuais, na ordem aerodinâmica → carro → freio → piloto
+
+### Requirement: A atualização de carreira SHALL validar nome e duplicidade antes de gravar
+`ControleClassificacao.atualizaCarreira(String, CarreiraDadosSrv)` SHALL retornar `MsgSrv` (sem gravar) quando o nome do carro/piloto está vazio, excede 20 caracteres, ou já existe para outro jogador; SHALL gravar e retornar mensagem de sucesso quando a validação passa.
+
+#### Scenario: Nome de carro vazio é rejeitado
+- **WHEN** `atualizaCarreira(idUsuario, carreiraDados)` é chamado com `nomeCarro` vazio
+- **THEN** o retorno é um `MsgSrv` e `controlePersistencia.gravarDados` nunca é chamado
+
+#### Scenario: Nome de carro maior que 20 caracteres é rejeitado
+- **WHEN** `atualizaCarreira(idUsuario, carreiraDados)` é chamado com `nomeCarro` de mais de 20 caracteres
+- **THEN** o retorno é um `MsgSrv` e `controlePersistencia.gravarDados` nunca é chamado
+
+#### Scenario: Nome de carro duplicado é rejeitado
+- **WHEN** `controlePersistencia.existeNomeCarro(...)` retorna `true` para o nome informado
+- **THEN** `atualizaCarreira` retorna um `MsgSrv` e `controlePersistencia.gravarDados` nunca é chamado
+
+#### Scenario: Atualização válida grava e retorna sucesso
+- **WHEN** todos os dados são válidos e não há duplicidade de nome
+- **THEN** `controlePersistencia.gravarDados` é chamado uma vez e o retorno não é `MsgSrv` de erro nem `ErroServ`
+
+### Requirement: A criação de campeonato SHALL exigir sessão de cliente válida
+`ControleCampeonatoServidor.criarCampeonato` SHALL retornar `MsgSrv` de erro quando a sessão do cliente é nula, sem persistir nenhum dado.
+
+#### Scenario: Sessão nula é rejeitada
+- **WHEN** `criarCampeonato(clientPaddockPack)` é chamado com `clientPaddockPack.getSessaoCliente() == null`
+- **THEN** o retorno é um `MsgSrv` e nenhuma chamada de persistência ocorre
+
+### Requirement: A criação de sessão por nome SHALL reutilizar sessão existente para o mesmo usuário
+`ControlePaddockServidor.criarSessaoNome(String)` SHALL retornar uma sessão existente (atualizando `ultimaAtividade`) quando já existe um cliente com o mesmo `idUsuario` na lista de clientes ativos, e SHALL criar uma nova sessão com token gerado quando não existe.
+
+#### Scenario: Nome já existente reaproveita a sessão
+- **WHEN** já existe um `SessaoCliente` com `idUsuario` igual ao nome informado em `dadosPaddock.getClientes()`
+- **THEN** `criarSessaoNome(nome)` retorna um objeto referenciando essa mesma sessão, sem gerar um novo token
+
+#### Scenario: Nome novo cria sessão com token
+- **WHEN** não existe nenhum `SessaoCliente` com aquele `idUsuario`
+- **THEN** `criarSessaoNome(nome)` retorna uma nova sessão com `token` não nulo e `idUsuario` igual ao nome informado
+
+### Requirement: Os controles de pilotagem SHALL validar a existência do piloto antes de aplicar a mudança
+`ControleJogosServer.mudarGiroMotor`, `mudarAgressividadePiloto`, `mudarTracadoPiloto`, `mudarDrs`, `mudarErs` e `boxPiloto` SHALL retornar um resultado de falha (sem lançar exceção) quando o piloto identificado por `idPiloto` não é encontrado na sessão/jogo do cliente.
+
+#### Scenario: boxPiloto com piloto inexistente retorna falha sem exceção
+- **WHEN** `boxPiloto(sessaoCliente, idPiloto, ...)` é chamado e o piloto não é encontrado para essa sessão
+- **THEN** o método retorna `Boolean.FALSE` (ou equivalente de falha) em vez de lançar exceção

--- a/openspec/changes/archive/2026-06-30-add-unit-tests/specs/letsrace-endpoint-tests/spec.md
+++ b/openspec/changes/archive/2026-06-30-add-unit-tests/specs/letsrace-endpoint-tests/spec.md
@@ -1,0 +1,75 @@
+## ADDED Requirements
+
+### Requirement: LetsRace SHALL ser instanciável em teste sem o grafo real do servidor
+`LetsRace` SHALL expor uma forma de injetar `ControlePaddockServidor` e `CarregadorRecursos` em testes, sem acionar `PaddockServer.init` (que constrói `ControlePersistencia`/Hibernate e inicia uma thread de monitoramento). O construtor público sem argumentos usado pelo Jersey em produção NÃO SHALL mudar de comportamento.
+
+#### Scenario: Construtor de teste injeta dependências mockadas
+- **WHEN** um teste cria `new LetsRace(carregadorRecursosMock, controlePaddockMock)`
+- **THEN** nenhuma conexão de banco, thread de monitoramento ou leitura de classpath é acionada
+
+#### Scenario: Construtor público de produção preserva comportamento
+- **WHEN** o Jersey instancia `LetsRace` via construtor sem argumentos
+- **THEN** o `controlePaddock` resultante é o mesmo retornado por `PaddockServer.getControlePaddock()`, igual ao comportamento antes desta mudança
+
+### Requirement: Endpoints que exigem sessão SHALL retornar 401 quando o token é inválido
+Todo endpoint de `LetsRace` que chama `controlePaddock.obterSessaoPorToken(token)` SHALL retornar HTTP 401 quando esse método retorna `null`, sem chamar nenhum outro método do controller.
+
+#### Scenario: jogar() com token inválido retorna 401
+- **WHEN** `controlePaddock.obterSessaoPorToken(token)` retorna `null` e `jogar(...)` é chamado
+- **THEN** a resposta tem status 401 e `controlePaddock.jogar(...)` nunca é chamado
+
+#### Scenario: equipe() com token inválido retorna 401
+- **WHEN** `controlePaddock.obterSessaoPorToken(token)` retorna `null` e `equipe(token, idioma)` é chamado
+- **THEN** a resposta tem status 401
+
+#### Scenario: dadosParciais() com token inválido retorna 401
+- **WHEN** `controlePaddock.obterSessaoPorToken(token)` retorna `null` e `dadosParciais(...)` é chamado
+- **THEN** a resposta tem status 401
+
+### Requirement: campeonato() SHALL retornar 403 para sessão de visitante
+`campeonato(token, idioma)` SHALL retornar HTTP 403 quando `sessaoCliente.isGuest()` é verdadeiro, sem chamar `controlePaddock.obterCampeonatoEmAberto`.
+
+#### Scenario: Visitante tenta acessar campeonato
+- **WHEN** a sessão retornada por `obterSessaoPorToken` tem `isGuest() == true`
+- **THEN** a resposta de `campeonato(token, idioma)` tem status 403
+
+### Requirement: processsaMensagem SHALL mapear MsgSrv para 400 e ErroServ para 500
+Endpoints que delegam a resposta de negócio para `processsaMensagem` (`jogar`, `jogarCampeonato`, `equipe`, `equipePilotoCarro`, `gravarEquipe`, `gravarCampeonato`) SHALL retornar HTTP 400 com a mensagem traduzida quando o controller retorna `MsgSrv`, e HTTP 500 com o erro formatado quando o controller retorna `ErroServ`.
+
+#### Scenario: jogar() com MsgSrv retorna 400
+- **WHEN** `controlePaddock.jogar(...)` retorna uma instância de `MsgSrv`
+- **THEN** a resposta de `jogar(...)` tem status 400 e o corpo contém a mensagem traduzida via `Lang.decodeTextoKey`
+
+#### Scenario: jogar() com ErroServ retorna 500
+- **WHEN** `controlePaddock.jogar(...)` retorna uma instância de `ErroServ`
+- **THEN** a resposta de `jogar(...)` tem status 500 e o corpo contém o texto de `erroServ.obterErroFormatado()`
+
+#### Scenario: jogar() com sucesso retorna 200 com o payload do controller
+- **WHEN** `controlePaddock.jogar(...)` retorna um objeto que não é `MsgSrv` nem `ErroServ`
+- **THEN** a resposta de `jogar(...)` tem status 200 e o corpo é exatamente o objeto retornado pelo controller
+
+### Requirement: criarSessaoNome SHALL retornar 500 quando o controller falha
+`criarSessaoNome(nome)` SHALL retornar HTTP 500 com o `ErroServ` serializável quando `controlePaddock.criarSessaoNome(nome)` retorna uma instância de `ErroServ`, e HTTP 200 com o payload de sessão caso contrário — cobrindo a regressão do bug corrigido nesta sessão (`ErroServ` sem `@JsonProperty` quebrava a serialização).
+
+#### Scenario: criarSessaoNome propaga erro do controller como 500
+- **WHEN** `controlePaddock.criarSessaoNome("nome")` retorna um `ErroServ`
+- **THEN** `criarSessaoNome("nome")` retorna status 500 com esse `ErroServ` como entity
+
+#### Scenario: criarSessaoNome de sucesso retorna 200
+- **WHEN** `controlePaddock.criarSessaoNome("nome")` retorna um `SrvPaddockPack`
+- **THEN** `criarSessaoNome("nome")` retorna status 200 com esse objeto como entity
+
+### Requirement: Endpoints de delegação simples SHALL repassar parâmetros e resultado corretamente
+Endpoints que apenas extraem parâmetros (header/path/query) e repassam para um método do controller — sem ramificação de status além de 200 (ex.: `obterJogos`, `verificaServico`, `circuitos`, `temporadas`, `potenciaMotor`, `agressividadePiloto`, `tracadoPiloto`, `drsPiloto`, `ersPiloto`, `boxPiloto`) — SHALL chamar o método correto do controller com os parâmetros corretos e devolver o resultado como entity da resposta 200.
+
+#### Scenario: potenciaMotor delega para mudarGiroMotor com os parâmetros corretos
+- **WHEN** `potenciaMotor(token, "GIRO_MAX", "piloto1")` é chamado com sessão válida
+- **THEN** `controleJogosServer.mudarGiroMotor(sessaoCliente, "piloto1", "GIRO_MAX")` é chamado exatamente uma vez e seu retorno é o entity da resposta 200
+
+#### Scenario: boxPiloto delega todos os parâmetros de pit stop
+- **WHEN** `boxPiloto(token, "piloto1", true, "MACIO", 50, "BAIXA")` é chamado com sessão válida
+- **THEN** `controleJogosServer.boxPiloto(sessaoCliente, "piloto1", true, "MACIO", 50, "BAIXA")` é chamado exatamente uma vez
+
+#### Scenario: verificaServico não depende de sessão nem controller
+- **WHEN** `verificaServico()` é chamado
+- **THEN** a resposta tem status 200 e corpo `"ok"`, sem chamar `controlePaddock`

--- a/openspec/changes/archive/2026-06-30-add-unit-tests/specs/unit-testing-infra/spec.md
+++ b/openspec/changes/archive/2026-06-30-add-unit-tests/specs/unit-testing-infra/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: O projeto SHALL ter infraestrutura de testes unitários executável via Maven
+O `pom.xml` SHALL declarar JUnit 5 e Mockito como dependências de escopo `test`, e o `maven-surefire-plugin` SHALL estar configurado para descobrir e executar testes JUnit 5 ao rodar `mvn test`. A adição dessas dependências NÃO SHALL alterar o conteúdo do jar de produção gerado por `mvn clean package -Ph2 -DskipTests` ou `-Pmysql -DskipTests`.
+
+#### Scenario: mvn test executa a suíte
+- **WHEN** `mvn test` é executado na raiz do projeto
+- **THEN** todas as classes em `src/test/java` cujo nome termina em `Test` são executadas e o build reporta sucesso se todas passarem
+
+#### Scenario: Build de produção não é afetado
+- **WHEN** `mvn clean package -Ph2 -DskipTests` é executado
+- **THEN** o `target/flmane.jar` gerado não contém nenhuma classe de `src/test/java` nem as dependências de teste (JUnit, Mockito) no classpath empacotado
+
+### Requirement: A estrutura de testes SHALL espelhar os pacotes de produção
+Cada classe de teste SHALL viver em `src/test/java/<mesmo-pacote-da-classe-testada>`, seguindo a convenção padrão do Maven (`testSourceDirectory` default), sem necessidade de configuração adicional no `pom.xml` para localizar os testes.
+
+#### Scenario: Teste de Util fica no pacote br.nnpe
+- **WHEN** o arquivo `src/test/java/br/nnpe/UtilTest.java` é lido
+- **THEN** ele declara `package br.nnpe;`, o mesmo pacote de `src/main/java/br/nnpe/Util.java`
+
+### Requirement: O cálculo de pontos de carreira SHALL ter cobertura de teste unitário
+`Util.processaValorPontosCarreira` SHALL ter testes unitários cobrindo a tabela de custo por faixa de nível (documentada em `openspec/specs/distribuicao-pontos-carreira/spec.md`), incluindo o caso de regressão do bug de pontos infinitos no nível 999 (commit `f47e7a74`).
+
+#### Scenario: Upgrade 998→999 custa 50 pontos
+- **WHEN** `processaValorPontosCarreira(998, 999, numero)` é chamado com um `Numero` cujo valor inicial é conhecido
+- **THEN** o valor do `Numero` após a chamada é igual ao valor inicial menos 50
+
+#### Scenario: Downgrade 999→998 devolve 50 pontos
+- **WHEN** `processaValorPontosCarreira(999, 998, numero)` é chamado com um `Numero` cujo valor inicial é conhecido
+- **THEN** o valor do `Numero` após a chamada é igual ao valor inicial mais 50
+
+#### Scenario: Ciclo downgrade seguido de upgrade no nível 999 não altera o saldo
+- **WHEN** `processaValorPontosCarreira(999, 998, numero)` é chamado e, em seguida, `processaValorPontosCarreira(998, 999, numero)` é chamado sobre o mesmo `Numero`
+- **THEN** o valor final do `Numero` é igual ao valor antes do primeiro chamado
+
+#### Scenario: Custo segue a tabela de faixas abaixo de 999
+- **WHEN** `processaValorPontosCarreira` é chamado com pares de nível-atual/nível-alvo cobrindo cada faixa (≤599, 600-699, 700-799, 800-899, 900-999) tanto em upgrade quanto em downgrade
+- **THEN** o débito ou crédito aplicado ao `Numero` corresponde exatamente ao custo por ponto definido na tabela da faixa do nível-alvo
+
+### Requirement: O comando de teste SHALL estar documentado no CLAUDE.md
+A seção "Build & Run" do `CLAUDE.md` SHALL incluir o comando `mvn test` como parte do fluxo de verificação local.
+
+#### Scenario: CLAUDE.md menciona mvn test
+- **WHEN** `CLAUDE.md` é lido
+- **THEN** a seção "Build & Run" contém o comando `mvn test`

--- a/openspec/changes/archive/2026-06-30-add-unit-tests/tasks.md
+++ b/openspec/changes/archive/2026-06-30-add-unit-tests/tasks.md
@@ -1,0 +1,95 @@
+## 1. Infraestrutura de testes
+
+- [x] 1.1 Adicionar dependências `org.junit.jupiter:junit-jupiter` e `org.mockito:mockito-core` (escopo `test`) ao `pom.xml`
+- [x] 1.2 Configurar `maven-surefire-plugin` (versão compatível com Java 21 / JUnit 5) no `pom.xml`
+- [x] 1.3 Criar diretório `src/test/java` e validar que `mvn test` roda (mesmo sem nenhum teste ainda) sem erro
+- [x] 1.4 Confirmar que `mvn clean package -Ph2 -DskipTests` continua gerando o jar normalmente, sem classes/deps de teste empacotadas
+
+## 2. Tornar LetsRace testável
+
+- [x] 2.1 Adicionar construtor pacote-privado `LetsRace(CarregadorRecursos, ControlePaddockServidor)` em `LetsRace.java`
+- [x] 2.2 Fazer o construtor público sem argumentos delegar para o novo construtor com os mesmos valores de hoje (`CarregadorRecursos.getCarregadorRecursos(false)`, `PaddockServer.getControlePaddock()`)
+- [x] 2.3 Validar que o jar continua subindo e respondendo via Jersey normalmente após a mudança (smoke test manual: `GET /flmane/rest/letsRace/verificaServico`)
+
+## 3. Testes de LetsRace
+
+- [x] 3.1 Criar `src/test/java/br/f1mane/servidor/rest/LetsRaceTest.java` com mocks de `ControlePaddockServidor`/`ControleJogosServer` via Mockito
+- [x] 3.2 Testes de autenticação: 401 quando `obterSessaoPorToken` retorna null (`jogar`, `equipe`, `dadosParciais`, `sairJogo`, `potenciaMotor`, etc.)
+- [x] 3.3 Teste de autorização: 403 em `campeonato()` para sessão guest
+- [x] 3.4 Testes de `processsaMensagem`: `MsgSrv`→400, `ErroServ`→500, sucesso→200, aplicados a `jogar`, `equipe`, `gravarEquipe`
+- [x] 3.5 Testes de `criarSessaoNome`/`criarSessaoGoogle`: sucesso→200, `ErroServ`→500 (regressão do bug desta sessão)
+- [x] 3.6 Testes de delegação simples para os endpoints de controle de piloto: `potenciaMotor`, `agressividadePiloto`, `tracadoPiloto`, `drsPiloto`, `ersPiloto`, `boxPiloto`
+- [x] 3.7 Testes dos demais endpoints de leitura (`obterJogos`, `verificaServico`, `circuitos`, `classificacaoGeral`, `classificacaoEquipes`, `classificacaoCampeonato`, `dadosToken`, `atualizarDadosVisao`, `campeonatoPorId`, `sairJogo`)
+- [x] 3.8 Rodar `mvn test` e confirmar 100% de sucesso em `LetsRaceTest` (37 testes)
+
+## 4. Testes de Util.processaValorPontosCarreira (segunda prioridade)
+
+- [x] 4.1 Criar `src/test/java/br/nnpe/UtilTest.java`
+- [x] 4.2 Teste: upgrade 998→999 debita 50 pontos; downgrade 999→998 credita 50 pontos
+- [x] 4.3 Teste: ciclo downgrade+upgrade no nível 999 não altera o saldo (regressão do bug de pontos infinitos)
+- [x] 4.4 Teste parametrizado cobrindo a tabela de custo por faixa, incluindo o bump simétrico de transição de centena cheia (600/700/800/900) tanto no upgrade quanto no downgrade
+
+## 5. Documentação
+
+- [x] 5.1 Adicionar `mvn test` à seção "Build & Run" do `CLAUDE.md`
+
+## 6. Validação final
+
+- [x] 6.1 Rodar `mvn test` completo e confirmar 100% de sucesso (60/60 testes)
+- [x] 6.2 Rodar `mvn clean package -Ph2 -DskipTests` e confirmar que o build de produção segue inalterado (jar sem classes/deps de teste)
+
+## Follow-up (fora do escopo desta mudança)
+
+- Endpoints de imagem (`circuitoJpg`, `circuitoBg`, `circuitoMini`, `objetoPista`, `carroCima*`, `capacete`, `png`) e `temporadas()`/`temporadasPilotos()`/`lang()`/`sobre()` não foram cobertos — são delegação simples sem ramificação de status relevante, ou (no caso de `temporadas()`) chamam um método **estático** de `CarregadorRecursos` via referência de instância, o que impede interceptar a chamada com um mock de instância sem refatorar a assinatura para `static`.
+- Achado durante a implementação, não corrigido (fora do pedido original): `finalizaCampeonato()` em `LetsRace.java` sempre retorna HTTP 200 com o `campeonato` de entrada, mesmo quando `controlePaddock.finalizaCampeonato(...)` lança exceção — o retorno do controller (`ret`) é calculado mas nunca usado. Vale uma mudança própria se for intencional revisar.
+
+## 7. Testes de ControleClassificacao
+
+- [x] 7.1 Criar `src/test/java/br/f1mane/servidor/controles/ControleClassificacaoTest.java`
+- [x] 7.2 Teste parametrizado de `gerarPontos` cobrindo posições 1-10 e uma posição fora do pódio de pontos
+- [x] 7.3 Testes de `validadeDistribuicaoPontos`: upgrade único, downgrade único, e mudança simultânea em múltiplos atributos
+- [x] 7.4 Testes de `atualizaCarreira`: nome vazio, nome >20 caracteres, nome duplicado (mock de `existeNomeCarro`/`existeNomePiloto`), e caminho de sucesso (21 testes)
+
+## 8. Testes de ControleCampeonatoServidor
+
+- [x] 8.1 Criar `src/test/java/br/f1mane/servidor/controles/ControleCampeonatoServidorTest.java`
+- [x] 8.2 Teste: `criarCampeonato` com sessão de cliente nula retorna erro sem persistir
+- [x] 8.3 Testes adicionais: validações de entrada (nome/piloto/corridas), campeonato em aberto, nome duplicado, jogador não encontrado, `verificaCampeonatoConcluido`, `finalizaCampeonato` (id correspondente/divergente/inexistente/exceção) (14 testes)
+
+## 9. Testes de ControlePaddockServidor
+
+- [x] 9.1 Criar `src/test/java/br/f1mane/servidor/controles/ControlePaddockServidorTest.java`
+- [x] 9.2 Testes de `criarSessaoNome`: reaproveita sessão existente vs. cria nova com token
+- [x] 9.3 Testes de `criarSessaoGoogle`/`criarSessaoVisitante`/`obterSessaoPorToken`/`renovarSessaoVisitante` (11 testes) — exercitam de ponta a ponta o caminho que causou o bug de `criarSessaoNome` desta sessão (não mockado, é a implementação real)
+
+## 10. Testes de ControleJogosServer
+
+- [x] 10.1 Criar `src/test/java/br/f1mane/servidor/controles/ControleJogosServerTest.java`
+- [x] 10.2 Testes de `obterPilotoPorId`, `mudarGiroMotor`, `mudarAgressividadePiloto`, `boxPiloto` com piloto válido e piloto inexistente (10 testes)
+
+## 11. Testes de ControlePersistencia
+
+- [x] 11.1 Criar `src/test/java/br/f1mane/servidor/controles/ControlePersistenciaTest.java`
+- [x] 11.2 `getSession()`/`Global.DATABASE=false` **não era testável**: `Global.DATABASE` era `public static final boolean = true` (constante de compilação), branch inalcançável. Substituído por: `carreiraDadosParaPiloto` (mapeamento puro carreira→piloto, com/sem livery) e `modoCarreira` (validação antes de gravar, via spy) (4 testes)
+
+## 12. Validação final do incremento
+
+- [x] 12.1 Rodar `mvn test` completo e confirmar 100% de sucesso (120/120 testes)
+- [x] 12.2 Rodar `mvn clean package -Ph2 -DskipTests` e confirmar que o build de produção segue inalterado (jar sem classes/deps de teste)
+
+## 13. Remoção de Global.DATABASE (código morto)
+
+- [x] 13.1 Remover o campo `public static final boolean DATABASE = true` de `Global.java` — era código morto desde sempre que ficou `final`: constante de compilação, sem forma de alternar em runtime; histórico do git mostra que era alternado manualmente (`true`/`false`/`!Logger.ativo`) e recompilado, nunca configurável de fato
+- [x] 13.2 Remover os 9 branches `if (!Global.DATABASE) { return ...; }` em `ControlePersistencia` (5), `ControleClassificacao` (3) e `ControlePaddockServidor` (1)
+- [x] 13.3 Remover imports órfãos de `br.nnpe.Global` em `ControlePersistencia.java` e `ControlePaddockServidor.java`
+- [x] 13.4 Rodar `mvn test` (120/120) e `mvn clean package -Ph2 -DskipTests` para confirmar que nada quebrou
+
+## 14. Injeção de dependência de CarregadorRecursos em ControleClassificacao/ControleCampeonatoServidor/ControlePaddockServidor
+
+- [x] 14.1 Adicionar construtor pacote-privado em `ControleClassificacao` recebendo `CarregadorRecursos`; construtor público delega com `CarregadorRecursos.getCarregadorRecursos(false)`
+- [x] 14.2 Mesmo padrão em `ControleCampeonatoServidor`
+- [x] 14.3 Mesmo padrão em `ControlePaddockServidor`, repassando o `CarregadorRecursos` injetado para as instâncias internas de `ControleCampeonatoServidor`/`ControleClassificacao` que ele constrói
+- [x] 14.4 `ControleClassificacaoTest`: cobrir validação de capacete (`pinturaCapacete`, bloqueado e permitido) e de carro (`pinturaCarro`, bloqueado) em `atualizaCarreira`, com `CarregadorRecursos` mockado (3 testes novos)
+- [x] 14.5 `ControleCampeonatoServidorTest`: cobrir o caminho de sucesso completo de `criarCampeonato` (grava e retorna `MsgSrv` de sucesso), com `TemporadasDefault` mockado via `CarregadorRecursos` (1 teste novo)
+- [x] 14.6 `ControlePaddockServidorTest`: migrar para o construtor injetável por consistência (sem novos testes — os métodos que usam `carregadorRecursos` ali são majoritariamente geração de imagem, já fora de escopo)
+- [x] 14.7 Rodar `mvn test` (124/124) e `mvn clean package -Ph2 -DskipTests` para confirmar que nada quebrou

--- a/openspec/specs/controles-business-logic-tests/spec.md
+++ b/openspec/specs/controles-business-logic-tests/spec.md
@@ -1,0 +1,80 @@
+# controles-business-logic-tests
+
+## Purpose
+
+Cobertura de teste unitário da lógica de negócio real nas 5 classes de `br.f1mane.servidor.controles` (`ControlePaddockServidor`, `ControleJogosServer`, `ControleClassificacao`, `ControleCampeonatoServidor`, `ControlePersistencia`), mockando `ControlePersistencia`/`Session` do Hibernate através dos construtores já existentes, sem exigir refactor de produção.
+
+## Requirements
+
+### Requirement: As classes de br.f1mane.servidor.controles SHALL ser testáveis sem mudança de produção
+Testes unitários das classes `ControlePaddockServidor`, `ControleJogosServer`, `ControleClassificacao`, `ControleCampeonatoServidor` e `ControlePersistencia` SHALL usar os construtores já existentes dessas classes, mockando `ControlePersistencia` (e `org.hibernate.Session`/`Transaction` quando necessário) via Mockito. Nenhum construtor novo ou mudança de visibilidade SHALL ser necessária nessas 5 classes.
+
+#### Scenario: ControleClassificacao é testável mockando apenas ControlePersistencia
+- **WHEN** um teste cria `new ControleClassificacao(controlePersistenciaMock, controleCampeonatoServidorMock)`
+- **THEN** nenhuma conexão de banco real é acionada
+
+### Requirement: A tabela de pontos por posição SHALL ter cobertura de teste
+`ControleClassificacao.gerarPontos(Piloto)` SHALL retornar os pontos corretos conforme a tabela de pontuação por posição de chegada (1º:25, 2º:18, 3º:15, 4º:12, 5º:10, 6º:8, 7º:6, 8º:4, 9º:2, 10º:1, 11º em diante:0).
+
+#### Scenario: Posições de pontuação retornam o valor correto
+- **WHEN** `gerarPontos(piloto)` é chamado com `piloto.getPosicao()` igual a cada uma das posições 1 a 10
+- **THEN** o retorno corresponde exatamente ao valor da tabela de pontos por posição
+
+#### Scenario: Posição fora do pódio de pontos retorna zero
+- **WHEN** `gerarPontos(piloto)` é chamado com `piloto.getPosicao()` igual a 11 ou maior
+- **THEN** o retorno é 0
+
+### Requirement: A validação de redistribuição de pontos SHALL ter cobertura de teste
+`ControleClassificacao.validadeDistribuicaoPontos` (que orquestra `Util.processaValorPontosCarreira` por atributo) SHALL calcular corretamente o saldo de pontos de construtores ao mudar múltiplos atributos (aerodinâmica, carro, freio, piloto) simultaneamente, incluindo o caso de regressão do bug de pontos infinitos no nível 999.
+
+#### Scenario: Upgrade de um único atributo debita o custo correto
+- **WHEN** `validadeDistribuicaoPontos` é chamado com um único atributo subindo de nível dentro da mesma faixa de custo
+- **THEN** o saldo retornado é igual ao saldo base menos o custo daquele atributo
+
+#### Scenario: Mudança simultânea em múltiplos atributos soma os custos/refunds corretamente
+- **WHEN** `validadeDistribuicaoPontos` é chamado com dois atributos subindo e um descendo ao mesmo tempo
+- **THEN** o saldo retornado reflete a soma de todos os débitos e créditos individuais, na ordem aerodinâmica → carro → freio → piloto
+
+### Requirement: A atualização de carreira SHALL validar nome e duplicidade antes de gravar
+`ControleClassificacao.atualizaCarreira(String, CarreiraDadosSrv)` SHALL retornar `MsgSrv` (sem gravar) quando o nome do carro/piloto está vazio, excede 20 caracteres, ou já existe para outro jogador; SHALL gravar e retornar mensagem de sucesso quando a validação passa.
+
+#### Scenario: Nome de carro vazio é rejeitado
+- **WHEN** `atualizaCarreira(idUsuario, carreiraDados)` é chamado com `nomeCarro` vazio
+- **THEN** o retorno é um `MsgSrv` e `controlePersistencia.gravarDados` nunca é chamado
+
+#### Scenario: Nome de carro maior que 20 caracteres é rejeitado
+- **WHEN** `atualizaCarreira(idUsuario, carreiraDados)` é chamado com `nomeCarro` de mais de 20 caracteres
+- **THEN** o retorno é um `MsgSrv` e `controlePersistencia.gravarDados` nunca é chamado
+
+#### Scenario: Nome de carro duplicado é rejeitado
+- **WHEN** `controlePersistencia.existeNomeCarro(...)` retorna `true` para o nome informado
+- **THEN** `atualizaCarreira` retorna um `MsgSrv` e `controlePersistencia.gravarDados` nunca é chamado
+
+#### Scenario: Atualização válida grava e retorna sucesso
+- **WHEN** todos os dados são válidos e não há duplicidade de nome
+- **THEN** `controlePersistencia.gravarDados` é chamado uma vez e o retorno não é `MsgSrv` de erro nem `ErroServ`
+
+### Requirement: A criação de campeonato SHALL exigir sessão de cliente válida
+`ControleCampeonatoServidor.criarCampeonato` SHALL retornar `MsgSrv` de erro quando a sessão do cliente é nula, sem persistir nenhum dado.
+
+#### Scenario: Sessão nula é rejeitada
+- **WHEN** `criarCampeonato(clientPaddockPack)` é chamado com `clientPaddockPack.getSessaoCliente() == null`
+- **THEN** o retorno é um `MsgSrv` e nenhuma chamada de persistência ocorre
+
+### Requirement: A criação de sessão por nome SHALL reutilizar sessão existente para o mesmo usuário
+`ControlePaddockServidor.criarSessaoNome(String)` SHALL retornar uma sessão existente (atualizando `ultimaAtividade`) quando já existe um cliente com o mesmo `idUsuario` na lista de clientes ativos, e SHALL criar uma nova sessão com token gerado quando não existe.
+
+#### Scenario: Nome já existente reaproveita a sessão
+- **WHEN** já existe um `SessaoCliente` com `idUsuario` igual ao nome informado em `dadosPaddock.getClientes()`
+- **THEN** `criarSessaoNome(nome)` retorna um objeto referenciando essa mesma sessão, sem gerar um novo token
+
+#### Scenario: Nome novo cria sessão com token
+- **WHEN** não existe nenhum `SessaoCliente` com aquele `idUsuario`
+- **THEN** `criarSessaoNome(nome)` retorna uma nova sessão com `token` não nulo e `idUsuario` igual ao nome informado
+
+### Requirement: Os controles de pilotagem SHALL validar a existência do piloto antes de aplicar a mudança
+`ControleJogosServer.mudarGiroMotor`, `mudarAgressividadePiloto`, `mudarTracadoPiloto`, `mudarDrs`, `mudarErs` e `boxPiloto` SHALL retornar um resultado de falha (sem lançar exceção) quando o piloto identificado por `idPiloto` não é encontrado na sessão/jogo do cliente.
+
+#### Scenario: boxPiloto com piloto inexistente retorna falha sem exceção
+- **WHEN** `boxPiloto(sessaoCliente, idPiloto, ...)` é chamado e o piloto não é encontrado para essa sessão
+- **THEN** o método retorna `Boolean.FALSE` (ou equivalente de falha) em vez de lançar exceção

--- a/openspec/specs/letsrace-endpoint-tests/spec.md
+++ b/openspec/specs/letsrace-endpoint-tests/spec.md
@@ -1,0 +1,81 @@
+# letsrace-endpoint-tests
+
+## Purpose
+
+Cobertura de teste unitário da camada REST `LetsRace` (`br.f1mane.servidor.rest.LetsRace`), o único ponto de entrada HTTP do modo multiplayer (38 endpoints) — autenticação/autorização, mapeamento de erro para status HTTP, e delegação correta para os controllers de jogo (`ControlePaddockServidor`/`ControleJogosServer`).
+
+## Requirements
+
+### Requirement: LetsRace SHALL ser instanciável em teste sem o grafo real do servidor
+`LetsRace` SHALL expor uma forma de injetar `ControlePaddockServidor` e `CarregadorRecursos` em testes, sem acionar `PaddockServer.init` (que constrói `ControlePersistencia`/Hibernate e inicia uma thread de monitoramento). O construtor público sem argumentos usado pelo Jersey em produção NÃO SHALL mudar de comportamento.
+
+#### Scenario: Construtor de teste injeta dependências mockadas
+- **WHEN** um teste cria `new LetsRace(carregadorRecursosMock, controlePaddockMock)`
+- **THEN** nenhuma conexão de banco, thread de monitoramento ou leitura de classpath é acionada
+
+#### Scenario: Construtor público de produção preserva comportamento
+- **WHEN** o Jersey instancia `LetsRace` via construtor sem argumentos
+- **THEN** o `controlePaddock` resultante é o mesmo retornado por `PaddockServer.getControlePaddock()`, igual ao comportamento antes desta mudança
+
+### Requirement: Endpoints que exigem sessão SHALL retornar 401 quando o token é inválido
+Todo endpoint de `LetsRace` que chama `controlePaddock.obterSessaoPorToken(token)` SHALL retornar HTTP 401 quando esse método retorna `null`, sem chamar nenhum outro método do controller.
+
+#### Scenario: jogar() com token inválido retorna 401
+- **WHEN** `controlePaddock.obterSessaoPorToken(token)` retorna `null` e `jogar(...)` é chamado
+- **THEN** a resposta tem status 401 e `controlePaddock.jogar(...)` nunca é chamado
+
+#### Scenario: equipe() com token inválido retorna 401
+- **WHEN** `controlePaddock.obterSessaoPorToken(token)` retorna `null` e `equipe(token, idioma)` é chamado
+- **THEN** a resposta tem status 401
+
+#### Scenario: dadosParciais() com token inválido retorna 401
+- **WHEN** `controlePaddock.obterSessaoPorToken(token)` retorna `null` e `dadosParciais(...)` é chamado
+- **THEN** a resposta tem status 401
+
+### Requirement: campeonato() SHALL retornar 403 para sessão de visitante
+`campeonato(token, idioma)` SHALL retornar HTTP 403 quando `sessaoCliente.isGuest()` é verdadeiro, sem chamar `controlePaddock.obterCampeonatoEmAberto`.
+
+#### Scenario: Visitante tenta acessar campeonato
+- **WHEN** a sessão retornada por `obterSessaoPorToken` tem `isGuest() == true`
+- **THEN** a resposta de `campeonato(token, idioma)` tem status 403
+
+### Requirement: processsaMensagem SHALL mapear MsgSrv para 400 e ErroServ para 500
+Endpoints que delegam a resposta de negócio para `processsaMensagem` (`jogar`, `jogarCampeonato`, `equipe`, `equipePilotoCarro`, `gravarEquipe`, `gravarCampeonato`) SHALL retornar HTTP 400 com a mensagem traduzida quando o controller retorna `MsgSrv`, e HTTP 500 com o erro formatado quando o controller retorna `ErroServ`.
+
+#### Scenario: jogar() com MsgSrv retorna 400
+- **WHEN** `controlePaddock.jogar(...)` retorna uma instância de `MsgSrv`
+- **THEN** a resposta de `jogar(...)` tem status 400 e o corpo contém a mensagem traduzida via `Lang.decodeTextoKey`
+
+#### Scenario: jogar() com ErroServ retorna 500
+- **WHEN** `controlePaddock.jogar(...)` retorna uma instância de `ErroServ`
+- **THEN** a resposta de `jogar(...)` tem status 500 e o corpo contém o texto de `erroServ.obterErroFormatado()`
+
+#### Scenario: jogar() com sucesso retorna 200 com o payload do controller
+- **WHEN** `controlePaddock.jogar(...)` retorna um objeto que não é `MsgSrv` nem `ErroServ`
+- **THEN** a resposta de `jogar(...)` tem status 200 e o corpo é exatamente o objeto retornado pelo controller
+
+### Requirement: criarSessaoNome SHALL retornar 500 quando o controller falha
+`criarSessaoNome(nome)` SHALL retornar HTTP 500 com o `ErroServ` serializável quando `controlePaddock.criarSessaoNome(nome)` retorna uma instância de `ErroServ`, e HTTP 200 com o payload de sessão caso contrário — cobrindo a regressão do bug corrigido nesta sessão (`ErroServ` sem `@JsonProperty` quebrava a serialização).
+
+#### Scenario: criarSessaoNome propaga erro do controller como 500
+- **WHEN** `controlePaddock.criarSessaoNome("nome")` retorna um `ErroServ`
+- **THEN** `criarSessaoNome("nome")` retorna status 500 com esse `ErroServ` como entity
+
+#### Scenario: criarSessaoNome de sucesso retorna 200
+- **WHEN** `controlePaddock.criarSessaoNome("nome")` retorna um `SrvPaddockPack`
+- **THEN** `criarSessaoNome("nome")` retorna status 200 com esse objeto como entity
+
+### Requirement: Endpoints de delegação simples SHALL repassar parâmetros e resultado corretamente
+Endpoints que apenas extraem parâmetros (header/path/query) e repassam para um método do controller — sem ramificação de status além de 200 (ex.: `obterJogos`, `verificaServico`, `circuitos`, `temporadas`, `potenciaMotor`, `agressividadePiloto`, `tracadoPiloto`, `drsPiloto`, `ersPiloto`, `boxPiloto`) — SHALL chamar o método correto do controller com os parâmetros corretos e devolver o resultado como entity da resposta 200.
+
+#### Scenario: potenciaMotor delega para mudarGiroMotor com os parâmetros corretos
+- **WHEN** `potenciaMotor(token, "GIRO_MAX", "piloto1")` é chamado com sessão válida
+- **THEN** `controleJogosServer.mudarGiroMotor(sessaoCliente, "piloto1", "GIRO_MAX")` é chamado exatamente uma vez e seu retorno é o entity da resposta 200
+
+#### Scenario: boxPiloto delega todos os parâmetros de pit stop
+- **WHEN** `boxPiloto(token, "piloto1", true, "MACIO", 50, "BAIXA")` é chamado com sessão válida
+- **THEN** `controleJogosServer.boxPiloto(sessaoCliente, "piloto1", true, "MACIO", 50, "BAIXA")` é chamado exatamente uma vez
+
+#### Scenario: verificaServico não depende de sessão nem controller
+- **WHEN** `verificaServico()` é chamado
+- **THEN** a resposta tem status 200 e corpo `"ok"`, sem chamar `controlePaddock`

--- a/openspec/specs/unit-testing-infra/spec.md
+++ b/openspec/specs/unit-testing-infra/spec.md
@@ -1,0 +1,51 @@
+# unit-testing-infra
+
+## Purpose
+
+Padrão e infraestrutura de testes unitários do projeto — onde os testes vivem, qual framework é usado, e como são executados como parte do build (`mvn test`), sem impactar o jar de produção.
+
+## Requirements
+
+### Requirement: O projeto SHALL ter infraestrutura de testes unitários executável via Maven
+O `pom.xml` SHALL declarar JUnit 5 e Mockito como dependências de escopo `test`, e o `maven-surefire-plugin` SHALL estar configurado para descobrir e executar testes JUnit 5 ao rodar `mvn test`. A adição dessas dependências NÃO SHALL alterar o conteúdo do jar de produção gerado por `mvn clean package -Ph2 -DskipTests` ou `-Pmysql -DskipTests`.
+
+#### Scenario: mvn test executa a suíte
+- **WHEN** `mvn test` é executado na raiz do projeto
+- **THEN** todas as classes em `src/test/java` cujo nome termina em `Test` são executadas e o build reporta sucesso se todas passarem
+
+#### Scenario: Build de produção não é afetado
+- **WHEN** `mvn clean package -Ph2 -DskipTests` é executado
+- **THEN** o `target/flmane.jar` gerado não contém nenhuma classe de `src/test/java` nem as dependências de teste (JUnit, Mockito) no classpath empacotado
+
+### Requirement: A estrutura de testes SHALL espelhar os pacotes de produção
+Cada classe de teste SHALL viver em `src/test/java/<mesmo-pacote-da-classe-testada>`, seguindo a convenção padrão do Maven (`testSourceDirectory` default), sem necessidade de configuração adicional no `pom.xml` para localizar os testes.
+
+#### Scenario: Teste de Util fica no pacote br.nnpe
+- **WHEN** o arquivo `src/test/java/br/nnpe/UtilTest.java` é lido
+- **THEN** ele declara `package br.nnpe;`, o mesmo pacote de `src/main/java/br/nnpe/Util.java`
+
+### Requirement: O cálculo de pontos de carreira SHALL ter cobertura de teste unitário
+`Util.processaValorPontosCarreira` SHALL ter testes unitários cobrindo a tabela de custo por faixa de nível (documentada em `openspec/specs/distribuicao-pontos-carreira/spec.md`), incluindo o caso de regressão do bug de pontos infinitos no nível 999 (commit `f47e7a74`).
+
+#### Scenario: Upgrade 998→999 custa 50 pontos
+- **WHEN** `processaValorPontosCarreira(998, 999, numero)` é chamado com um `Numero` cujo valor inicial é conhecido
+- **THEN** o valor do `Numero` após a chamada é igual ao valor inicial menos 50
+
+#### Scenario: Downgrade 999→998 devolve 50 pontos
+- **WHEN** `processaValorPontosCarreira(999, 998, numero)` é chamado com um `Numero` cujo valor inicial é conhecido
+- **THEN** o valor do `Numero` após a chamada é igual ao valor inicial mais 50
+
+#### Scenario: Ciclo downgrade seguido de upgrade no nível 999 não altera o saldo
+- **WHEN** `processaValorPontosCarreira(999, 998, numero)` é chamado e, em seguida, `processaValorPontosCarreira(998, 999, numero)` é chamado sobre o mesmo `Numero`
+- **THEN** o valor final do `Numero` é igual ao valor antes do primeiro chamado
+
+#### Scenario: Custo segue a tabela de faixas abaixo de 999
+- **WHEN** `processaValorPontosCarreira` é chamado com pares de nível-atual/nível-alvo cobrindo cada faixa (≤599, 600-699, 700-799, 800-899, 900-999) tanto em upgrade quanto em downgrade
+- **THEN** o débito ou crédito aplicado ao `Numero` corresponde exatamente ao custo por ponto definido na tabela da faixa do nível-alvo
+
+### Requirement: O comando de teste SHALL estar documentado no CLAUDE.md
+A seção "Build & Run" do `CLAUDE.md` SHALL incluir o comando `mvn test` como parte do fluxo de verificação local.
+
+#### Scenario: CLAUDE.md menciona mvn test
+- **WHEN** `CLAUDE.md` é lido
+- **THEN** a seção "Build & Run" contém o comando `mvn test`

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,18 @@
             <artifactId>logback-classic</artifactId>
             <version>1.5.18</version>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.11.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>5.15.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <finalName>flmane</finalName>
@@ -193,6 +205,31 @@
             <plugin>
                 <artifactId>maven-war-plugin</artifactId>
                 <version>3.4.0</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.2</version>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.12</version>
+                <executions>
+                    <execution>
+                        <id>jacoco-prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>jacoco-report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/br/f1mane/servidor/controles/ControleCampeonatoServidor.java
+++ b/src/main/java/br/f1mane/servidor/controles/ControleCampeonatoServidor.java
@@ -25,14 +25,20 @@ public class ControleCampeonatoServidor {
 
     private final ControlePersistencia controlePersistencia;
     private final ControlePaddockServidor controlePaddockServidor;
-    private final CarregadorRecursos carregadorRecursos = CarregadorRecursos
-            .getCarregadorRecursos(false);
+    private final CarregadorRecursos carregadorRecursos;
 
     public ControleCampeonatoServidor(ControlePersistencia controlePersistencia,
                                       ControlePaddockServidor controlePaddockServidor) {
+        this(controlePersistencia, controlePaddockServidor, CarregadorRecursos.getCarregadorRecursos(false));
+    }
+
+    ControleCampeonatoServidor(ControlePersistencia controlePersistencia,
+                               ControlePaddockServidor controlePaddockServidor,
+                               CarregadorRecursos carregadorRecursos) {
         super();
         this.controlePersistencia = controlePersistencia;
         this.controlePaddockServidor = controlePaddockServidor;
+        this.carregadorRecursos = carregadorRecursos;
     }
 
     public Object criarCampeonato(ClientPaddockPack clientPaddockPack) {

--- a/src/main/java/br/f1mane/servidor/controles/ControleClassificacao.java
+++ b/src/main/java/br/f1mane/servidor/controles/ControleClassificacao.java
@@ -20,16 +20,23 @@ import java.util.*;
 public class ControleClassificacao {
     private final ControlePersistencia controlePersistencia;
     private final ControleCampeonatoServidor controleCampeonatoServidor;
-    private final CarregadorRecursos carregadorRecursos = CarregadorRecursos.getCarregadorRecursos(false);
+    private final CarregadorRecursos carregadorRecursos;
 
     /**
      * @param controlePersistencia
      */
     public ControleClassificacao(ControlePersistencia controlePersistencia,
                                  ControleCampeonatoServidor controleCampeonatoServidor) {
+        this(controlePersistencia, controleCampeonatoServidor, CarregadorRecursos.getCarregadorRecursos(false));
+    }
+
+    ControleClassificacao(ControlePersistencia controlePersistencia,
+                          ControleCampeonatoServidor controleCampeonatoServidor,
+                          CarregadorRecursos carregadorRecursos) {
         super();
         this.controlePersistencia = controlePersistencia;
         this.controleCampeonatoServidor = controleCampeonatoServidor;
+        this.carregadorRecursos = carregadorRecursos;
     }
 
     public List obterListaClassificacao(Integer ano) {
@@ -76,9 +83,6 @@ public class ControleClassificacao {
 
     public void processaCorrida(long tempoInicio, long tempoFim, Map mapVoltasJogadoresOnline, List pilotos,
                                 DadosCriarJogo dadosCriarJogo) {
-        if (!Global.DATABASE) {
-            return;
-        }
         Session session = controlePersistencia.getSession();
         Transaction transaction = session.beginTransaction();
         try {
@@ -284,9 +288,6 @@ public class ControleClassificacao {
     }
 
     public Object verCarreira(ClientPaddockPack clientPaddockPack, Session session) {
-        if (!Global.DATABASE) {
-            return null;
-        }
         return verCarreira(clientPaddockPack.getSessaoCliente().getIdUsuario(), session);
     }
 
@@ -486,9 +487,6 @@ public class ControleClassificacao {
     }
 
     public CarreiraDadosSrv obterCarreiraSrv(String idUsuario) {
-        if (!Global.DATABASE) {
-            return null;
-        }
         Session session = controlePersistencia.getSession();
         try {
             CarreiraDadosSrv carreiraDadosSrv = controlePersistencia.carregaCarreiraJogador(idUsuario, false, session);

--- a/src/main/java/br/f1mane/servidor/controles/ControlePaddockServidor.java
+++ b/src/main/java/br/f1mane/servidor/controles/ControlePaddockServidor.java
@@ -14,7 +14,6 @@ import br.f1mane.servidor.entidades.TOs.DadosPaddock;
 import br.f1mane.servidor.entidades.TOs.SessaoCliente;
 import org.hibernate.Session;
 
-import br.nnpe.Global;
 import br.nnpe.Logger;
 import br.nnpe.PassGenerator;
 import br.nnpe.TokenGenerator;
@@ -51,7 +50,7 @@ public class ControlePaddockServidor {
     private final ControleCampeonatoServidor controleCampeonatoServidor;
     private int versao;
     private int contadorVistantes = 1;
-    private final CarregadorRecursos carregadorRecursos = CarregadorRecursos.getCarregadorRecursos(false);
+    private final CarregadorRecursos carregadorRecursos;
 
     public DadosPaddock getDadosPaddock() {
         return dadosPaddock;
@@ -62,9 +61,14 @@ public class ControlePaddockServidor {
     }
 
     public ControlePaddockServidor(ControlePersistencia controlePersistencia) {
+        this(controlePersistencia, CarregadorRecursos.getCarregadorRecursos(false));
+    }
+
+    ControlePaddockServidor(ControlePersistencia controlePersistencia, CarregadorRecursos carregadorRecursos) {
         this.controlePersistencia = controlePersistencia;
-        controleCampeonatoServidor = new ControleCampeonatoServidor(controlePersistencia, this);
-        controleClassificacao = new ControleClassificacao(controlePersistencia, controleCampeonatoServidor);
+        this.carregadorRecursos = carregadorRecursos;
+        controleCampeonatoServidor = new ControleCampeonatoServidor(controlePersistencia, this, carregadorRecursos);
+        controleClassificacao = new ControleClassificacao(controlePersistencia, controleCampeonatoServidor, carregadorRecursos);
         controleJogosServer = new ControleJogosServer(dadosPaddock, controleClassificacao, controleCampeonatoServidor,
                 controlePersistencia, this);
         try {
@@ -638,9 +642,6 @@ public class ControlePaddockServidor {
     }
 
     private void salvarAcessoSessaoId(SessaoCliente sessaoCliente) {
-        if (!Global.DATABASE) {
-            return;
-        }
         JogadorDadosSrv jogadorDadosSrv;
         Session session = controlePersistencia.getSession();
         try {

--- a/src/main/java/br/f1mane/servidor/controles/ControlePersistencia.java
+++ b/src/main/java/br/f1mane/servidor/controles/ControlePersistencia.java
@@ -6,7 +6,6 @@ import br.f1mane.recursos.idiomas.Lang;
 import br.f1mane.servidor.entidades.TOs.MsgSrv;
 import br.f1mane.servidor.entidades.persistencia.*;
 import br.f1mane.servidor.util.HibernateUtil;
-import br.nnpe.Global;
 import br.nnpe.Dia;
 import br.nnpe.Logger;
 import br.nnpe.Util;
@@ -25,9 +24,6 @@ public class ControlePersistencia {
     private final static String lock = "lock";
 
     public Session getSession() {
-        if (!Global.DATABASE) {
-            return null;
-        }
         return HibernateUtil.getSession();
     }
 
@@ -200,9 +196,6 @@ public class ControlePersistencia {
     }
 
     public List<CorridasDadosSrv> obterClassificacaoCircuito(String circuito, Session session) {
-        if (!Global.DATABASE) {
-            return null;
-        }
         return session.createQuery(
                 "from CorridasDadosSrv where circuito = :circuito and pontos > 0",
                 CorridasDadosSrv.class)
@@ -210,9 +203,6 @@ public class ControlePersistencia {
     }
 
     public List<CorridasDadosSrv> obterClassificacaoTemporada(String temporadaSelecionada, Session session) {
-        if (!Global.DATABASE) {
-            return null;
-        }
         return session.createQuery(
                 "from CorridasDadosSrv where temporada = :temporada and pontos > 0",
                 CorridasDadosSrv.class)
@@ -220,9 +210,6 @@ public class ControlePersistencia {
     }
 
     public CarreiraDadosSrv carregaCarreiraJogador(String idUsuario, boolean vaiCliente, Session session) {
-        if (!Global.DATABASE) {
-            return null;
-        }
         Logger.logar("Buscar Carreira idUsuario " + idUsuario);
         List<CarreiraDadosSrv> list = session.createQuery(
                 "from CarreiraDadosSrv c join fetch c.jogadorDadosSrv j where j.idUsuario = :idUsuario",
@@ -326,9 +313,6 @@ public class ControlePersistencia {
     }
 
     public MsgSrv modoCarreira(String idUsuario, boolean modo) {
-        if (!Global.DATABASE) {
-            return null;
-        }
         Session session = getSession();
         try {
             CarreiraDadosSrv carreiraDadosSrv = carregaCarreiraJogador(idUsuario, false, session);
@@ -379,9 +363,6 @@ public class ControlePersistencia {
     }
 
     public List<CorridasDadosSrv> obterClassificacaoGeral(Session session) {
-        if (!Global.DATABASE) {
-            return null;
-        }
         return session.createQuery(
                 "from CorridasDadosSrv where pontos > 0", CorridasDadosSrv.class).list();
     }

--- a/src/main/java/br/f1mane/servidor/rest/LetsRace.java
+++ b/src/main/java/br/f1mane/servidor/rest/LetsRace.java
@@ -53,10 +53,19 @@ import br.f1mane.visao.PainelCircuito;
 @Path("/letsRace")
 public class LetsRace {
 
-    private final CarregadorRecursos carregadorRecursos = CarregadorRecursos
-            .getCarregadorRecursos(false);
-    private final ControlePaddockServidor controlePaddock = PaddockServer
-            .getControlePaddock();
+    private final CarregadorRecursos carregadorRecursos;
+    private final ControlePaddockServidor controlePaddock;
+
+    public LetsRace() {
+        this(CarregadorRecursos.getCarregadorRecursos(false),
+                PaddockServer.getControlePaddock());
+    }
+
+    LetsRace(CarregadorRecursos carregadorRecursos,
+             ControlePaddockServidor controlePaddock) {
+        this.carregadorRecursos = carregadorRecursos;
+        this.controlePaddock = controlePaddock;
+    }
 
     private Response processsaMensagem(Object objeto, String idioma) {
         if (objeto == null) {

--- a/src/main/java/br/nnpe/Global.java
+++ b/src/main/java/br/nnpe/Global.java
@@ -6,7 +6,6 @@ public final class Global {
     public static final String DATA_FORMATO = "dd/MM/yyyy";
     public static final int MAX_VOLTAS = 72;
     public static final int MIN_VOLTAS = Global.DEBUG ? 1 : 12;
-    public static final boolean DATABASE = true;
     public static final int LATENCIA_MAX = 500;
     public static final int LATENCIA_MIN = 100;
     public static final int LIMITE_DRS = 300;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,7 +1,7 @@
-#Tue, 30 Jun 2026 16:24:28 -0300
+#Tue, 30 Jun 2026 17:34:49 -0300
 port=80
 host=localhost
-versao=6.905
+versao=6.911
 versaoMesAno=06-2026
 idGoogle=143142801251-n0a6bc0rs03h41bt7ganklmlrokqn6te.apps.googleusercontent.com
 applet=true

--- a/src/main/webapp/html5/campeonato.html
+++ b/src/main/webapp/html5/campeonato.html
@@ -5,7 +5,7 @@
 <meta name="viewport"
 	content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 <link rel="stylesheet" href="../bootstrap/css/bootstrap.min.css">
-<link rel="stylesheet" href="css/flmane.css?v=6.904">
+<link rel="stylesheet" href="css/flmane.css?v=6.910">
 <script src="../jquery/jquery-3.2.1.min.js"></script>
 <script src="../bootstrap/js/bootstrap.min.js"></script>
 
@@ -218,13 +218,13 @@
 		</div>				
 		<footer class="footer">
 			<div class="container">
-				<p>Build: 6.904</p>
+				<p>Build: 6.910</p>
 			</div>
 		</footer>
 	</div>
 </body>
-<script src="js/util.js?v=6.904"></script>
-<script src="js/loader.js?v=6.904"></script>
-<script src="js/lang.js?v=6.904"></script>
-<script src="js/campeonato.js?v=6.904"></script>
+<script src="js/util.js?v=6.910"></script>
+<script src="js/loader.js?v=6.910"></script>
+<script src="js/lang.js?v=6.910"></script>
+<script src="js/campeonato.js?v=6.910"></script>
 </html>

--- a/src/main/webapp/html5/classificacao.html
+++ b/src/main/webapp/html5/classificacao.html
@@ -5,8 +5,8 @@
 <meta name="viewport"
 	content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 <link rel="stylesheet" href="../bootstrap/css/bootstrap.min.css">
-<link rel="stylesheet" href="css/flmane.css?v=6.904">
-<link rel="stylesheet" href="css/mdb-btns.css?v=6.904">
+<link rel="stylesheet" href="css/flmane.css?v=6.910">
+<link rel="stylesheet" href="css/mdb-btns.css?v=6.910">
 <script src="../jquery/jquery-3.2.1.min.js"></script>
 <script src="../bootstrap/js/bootstrap.min.js"></script>
 
@@ -15,7 +15,7 @@
 <body class="body">
 <div id="f1body">
 	<section id="head" class="container" style="margin: 10px;">
-        <a href="index.html?v=6.904" id="voltar" class="voltar black">
+        <a href="index.html?v=6.910" id="voltar" class="voltar black">
           <span class="glyphicon glyphicon glyphicon-chevron-left" aria-hidden="true"></span> 
         </a>
 		<h3 style="display: inline;">Fl-Mane</h3>
@@ -27,34 +27,34 @@
 	</section>
 	<section id="mainContainer" class="container">
 		<div id="botoes" class="list-group">
-			<a href="classificacao_geral.html?v=6.904" class="list-group-item transparent">
+			<a href="classificacao_geral.html?v=6.910" class="list-group-item transparent">
 				<button type="button" id="classificacao_geral" class="btn btn-default btn-block btn-raised bgTransparent"></button>
 			</a> 
-			<a href="classificacao_circuito.html?v=6.904" class="list-group-item transparent">
+			<a href="classificacao_circuito.html?v=6.910" class="list-group-item transparent">
 				<button type="button" id="classificacao_circuito" class="btn btn-default btn-block btn-raised bgTransparent"></button>
 			</a>
-			<a href="classificacao_temporada.html?v=6.904" class="list-group-item transparent">
+			<a href="classificacao_temporada.html?v=6.910" class="list-group-item transparent">
 				<button type="button" id="classificacao_temporada" class="btn btn-default btn-block btn-raised bgTransparent"></button>
 			</a>
-			<a href="classificacao_equipes.html?v=6.904" class="list-group-item transparent">
+			<a href="classificacao_equipes.html?v=6.910" class="list-group-item transparent">
 				<button type="button" id="classificacao_equipes" class="btn btn-default btn-block btn-raised bgTransparent">classificacao_equipes</button>
 			</a>
-			<a href="classificacao_campeonato.html?v=6.904" class="list-group-item transparent">
+			<a href="classificacao_campeonato.html?v=6.910" class="list-group-item transparent">
 				<button type="button" id="classificacao_campeonato" class="btn btn-default btn-block btn-raised bgTransparent">classificacao_equipes</button>
 			</a>						
 		</div>
 	</section>
 	<footer class="footer">
 		<div class="container">
-			<p>Build: 6.904</p>
+			<p>Build: 6.910</p>
 		</div>
 	</footer>
 </div>	
 </body>
-<script src="js/util.js?v=6.904"></script>
-<script src="js/loader.js?v=6.904"></script>
-<script src="js/lang.js?v=6.904"></script>
-<script src="js/classificacao.js?v=6.904"></script>
+<script src="js/util.js?v=6.910"></script>
+<script src="js/loader.js?v=6.910"></script>
+<script src="js/lang.js?v=6.910"></script>
+<script src="js/classificacao.js?v=6.910"></script>
 <script>
 //Ripple-effect animation
 (function($) {

--- a/src/main/webapp/html5/classificacao_campeonato.html
+++ b/src/main/webapp/html5/classificacao_campeonato.html
@@ -5,8 +5,8 @@
 <meta name="viewport"
 	content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 <link rel="stylesheet" href="../bootstrap/css/bootstrap.min.css">
-<link rel="stylesheet" href="css/flmane.css?v=6.904">
-<link rel="stylesheet" href="css/mdb-btns.css?v=6.904">
+<link rel="stylesheet" href="css/flmane.css?v=6.910">
+<link rel="stylesheet" href="css/mdb-btns.css?v=6.910">
 <script src="../jquery/jquery-3.2.1.min.js"></script>
 <script src="../bootstrap/js/bootstrap.min.js"></script>
 
@@ -118,13 +118,13 @@
 		</section>
 		<footer class="footer">
 			<div class="container">
-				<p>Build: 6.904</p>
+				<p>Build: 6.910</p>
 			</div>
 		</footer>
 	</div>
 </body>
-<script src="js/util.js?v=6.904"></script>
-<script src="js/loader.js?v=6.904"></script>
-<script src="js/lang.js?v=6.904"></script>
-<script src="js/classificacao_campeonato.js?v=6.904"></script>
+<script src="js/util.js?v=6.910"></script>
+<script src="js/loader.js?v=6.910"></script>
+<script src="js/lang.js?v=6.910"></script>
+<script src="js/classificacao_campeonato.js?v=6.910"></script>
 </html>

--- a/src/main/webapp/html5/classificacao_circuito.html
+++ b/src/main/webapp/html5/classificacao_circuito.html
@@ -5,8 +5,8 @@
 <meta name="viewport"
 	content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 <link rel="stylesheet" href="../bootstrap/css/bootstrap.min.css">
-<link rel="stylesheet" href="css/flmane.css?v=6.904">
-<link rel="stylesheet" href="css/mdb-btns.css?v=6.904">
+<link rel="stylesheet" href="css/flmane.css?v=6.910">
+<link rel="stylesheet" href="css/mdb-btns.css?v=6.910">
 <script src="../jquery/jquery-3.2.1.min.js"></script>
 <script src="../bootstrap/js/bootstrap.min.js"></script>
 
@@ -15,7 +15,7 @@
 <body class="body">
 <div id="f1body">
 	<section id="head" class="container" style="margin: 10px;">
-        <a href="classificacao.html?v=6.904" id="voltar" class="voltar black">
+        <a href="classificacao.html?v=6.910" id="voltar" class="voltar black">
           <span class="glyphicon glyphicon glyphicon-chevron-left" aria-hidden="true"></span> 
         </a>
 		<h3 style="display: inline;">Fl-Mane</h3>
@@ -58,13 +58,13 @@
 	</section>
 	<footer class="footer">
 		<div class="container">
-			<p>Build: 6.904</p>
+			<p>Build: 6.910</p>
 		</div>
 	</footer>
 </div>	
 </body>
-<script src="js/util.js?v=6.904"></script>
-<script src="js/loader.js?v=6.904"></script>
-<script src="js/lang.js?v=6.904"></script>
-<script src="js/classificacao_circuito.js?v=6.904"></script>
+<script src="js/util.js?v=6.910"></script>
+<script src="js/loader.js?v=6.910"></script>
+<script src="js/lang.js?v=6.910"></script>
+<script src="js/classificacao_circuito.js?v=6.910"></script>
 </html>

--- a/src/main/webapp/html5/classificacao_equipes.html
+++ b/src/main/webapp/html5/classificacao_equipes.html
@@ -5,8 +5,8 @@
 <meta name="viewport"
 	content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 <link rel="stylesheet" href="../bootstrap/css/bootstrap.min.css">
-<link rel="stylesheet" href="css/flmane.css?v=6.904">
-<link rel="stylesheet" href="css/mdb-btns.css?v=6.904">
+<link rel="stylesheet" href="css/flmane.css?v=6.910">
+<link rel="stylesheet" href="css/mdb-btns.css?v=6.910">
 <script src="../jquery/jquery-3.2.1.min.js"></script>
 <script src="../bootstrap/js/bootstrap.min.js"></script>
 
@@ -15,7 +15,7 @@
 <body class="body">
 <div id="f1body">
 	<section id="head" class="container" style="margin: 10px;">
-        <a href="classificacao.html?v=6.904" id="voltar" class="voltar black">
+        <a href="classificacao.html?v=6.910" id="voltar" class="voltar black">
           <span class="glyphicon glyphicon glyphicon-chevron-left" aria-hidden="true"></span> 
         </a>
 		<h3 style="display: inline;">Fl-Mane</h3>
@@ -37,13 +37,13 @@
 	</section>
 	<footer class="footer">
 		<div class="container">
-			<p>Build: 6.904</p>
+			<p>Build: 6.910</p>
 		</div>
 	</footer>
 </div>	
 </body>
-<script src="js/util.js?v=6.904"></script>
-<script src="js/loader.js?v=6.904"></script>
-<script src="js/lang.js?v=6.904"></script>
-<script src="js/classificacao_equipes.js?v=6.904"></script>
+<script src="js/util.js?v=6.910"></script>
+<script src="js/loader.js?v=6.910"></script>
+<script src="js/lang.js?v=6.910"></script>
+<script src="js/classificacao_equipes.js?v=6.910"></script>
 </html>

--- a/src/main/webapp/html5/classificacao_geral.html
+++ b/src/main/webapp/html5/classificacao_geral.html
@@ -5,8 +5,8 @@
 <meta name="viewport"
 	content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 <link rel="stylesheet" href="../bootstrap/css/bootstrap.min.css">
-<link rel="stylesheet" href="css/flmane.css?v=6.904">
-<link rel="stylesheet" href="css/mdb-btns.css?v=6.904">
+<link rel="stylesheet" href="css/flmane.css?v=6.910">
+<link rel="stylesheet" href="css/mdb-btns.css?v=6.910">
 <script src="../jquery/jquery-3.2.1.min.js"></script>
 <script src="../bootstrap/js/bootstrap.min.js"></script>
 
@@ -15,7 +15,7 @@
 <body class="body">
 <div id="f1body">
 	<section id="head" class="container" style="margin: 10px;">
-        <a href="classificacao.html?v=6.904" id="voltar" class="voltar black">
+        <a href="classificacao.html?v=6.910" id="voltar" class="voltar black">
           <span class="glyphicon glyphicon glyphicon-chevron-left" aria-hidden="true"></span> 
         </a>
 		<h3 style="display: inline;">Fl-Mane</h3>
@@ -37,13 +37,13 @@
 	</section>
 	<footer class="footer">
 		<div class="container">
-			<p>Build: 6.904</p>
+			<p>Build: 6.910</p>
 		</div>
 	</footer>
 </div>	
 </body>
-<script src="js/util.js?v=6.904"></script>
-<script src="js/loader.js?v=6.904"></script>
-<script src="js/lang.js?v=6.904"></script>
-<script src="js/classificacao_geral.js?v=6.904"></script>
+<script src="js/util.js?v=6.910"></script>
+<script src="js/loader.js?v=6.910"></script>
+<script src="js/lang.js?v=6.910"></script>
+<script src="js/classificacao_geral.js?v=6.910"></script>
 </html>

--- a/src/main/webapp/html5/classificacao_temporada.html
+++ b/src/main/webapp/html5/classificacao_temporada.html
@@ -5,8 +5,8 @@
 <meta name="viewport"
 	content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 <link rel="stylesheet" href="../bootstrap/css/bootstrap.min.css">
-<link rel="stylesheet" href="css/flmane.css?v=6.904">
-<link rel="stylesheet" href="css/mdb-btns.css?v=6.904">
+<link rel="stylesheet" href="css/flmane.css?v=6.910">
+<link rel="stylesheet" href="css/mdb-btns.css?v=6.910">
 <script src="../jquery/jquery-3.2.1.min.js"></script>
 <script src="../bootstrap/js/bootstrap.min.js"></script>
 
@@ -15,7 +15,7 @@
 <body class="body">
 <div id="f1body">
 	<section id="head" class="container" style="margin: 10px;">
-        <a href="classificacao.html?v=6.904" id="voltar" class="voltar black">
+        <a href="classificacao.html?v=6.910" id="voltar" class="voltar black">
           <span class="glyphicon glyphicon glyphicon-chevron-left" aria-hidden="true"></span> 
         </a>
 		<h3 style="display: inline;">Fl-Mane</h3>
@@ -57,13 +57,13 @@
 	</section>
 	<footer class="footer">
 		<div class="container">
-			<p>Build: 6.904</p>
+			<p>Build: 6.910</p>
 		</div>
 	</footer>
 </div>	
 </body>
-<script src="js/util.js?v=6.904"></script>
-<script src="js/loader.js?v=6.904"></script>
-<script src="js/lang.js?v=6.904"></script>
-<script src="js/classificacao_temporada.js?v=6.904"></script>
+<script src="js/util.js?v=6.910"></script>
+<script src="js/loader.js?v=6.910"></script>
+<script src="js/lang.js?v=6.910"></script>
+<script src="js/classificacao_temporada.js?v=6.910"></script>
 </html>

--- a/src/main/webapp/html5/configuracao.html
+++ b/src/main/webapp/html5/configuracao.html
@@ -5,15 +5,15 @@
 <meta name="viewport"
 	content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 <link rel="stylesheet" href="../bootstrap/css/bootstrap.min.css">
-<link rel="stylesheet" href="css/flmane.css?v=6.904">
-<link rel="stylesheet" href="css/mdb-btns.css?v=6.904">
+<link rel="stylesheet" href="css/flmane.css?v=6.910">
+<link rel="stylesheet" href="css/mdb-btns.css?v=6.910">
 <script src="../jquery/jquery-3.2.1.min.js"></script>
 <title>Fl-Mane</title>
 </head>
 <body class="body">
 	<div id="f1body">
 		<section id="head" class="container" style="margin: 10px;">
-			<a href="index.html?v=6.904" class="voltar black"> <span
+			<a href="index.html?v=6.910" class="voltar black"> <span
 				class="glyphicon glyphicon glyphicon-chevron-left"
 				aria-hidden="true"></span>
 			</a>
@@ -42,16 +42,16 @@
 		</section>
 		<footer class="footer">
 			<div class="container">
-				<p>Build: 6.904</p>
-				<input id="versao" type="hidden" value="6.904" />
+				<p>Build: 6.910</p>
+				<input id="versao" type="hidden" value="6.910" />
 			</div>
 		</footer>
 	</div>
 </body>
-<script src="js/util.js?v=6.904"></script>
-<script src="js/loader.js?v=6.904"></script>
-<script src="js/lang.js?v=6.904"></script>
-<script src="js/tela.js?v=6.904"></script>
+<script src="js/util.js?v=6.910"></script>
+<script src="js/loader.js?v=6.910"></script>
+<script src="js/lang.js?v=6.910"></script>
+<script src="js/tela.js?v=6.910"></script>
 <script>
 	//Ripple-effect animation
 	(function($) {

--- a/src/main/webapp/html5/controles.html
+++ b/src/main/webapp/html5/controles.html
@@ -5,7 +5,7 @@
 <meta name="viewport"
 	content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 <link rel="stylesheet" href="../bootstrap/css/bootstrap.min.css">
-<link rel="stylesheet" href="css/flmane.css?v=6.904">
+<link rel="stylesheet" href="css/flmane.css?v=6.910">
 <script src="../jquery/jquery-3.2.1.min.js"></script>
 <script src="../bootstrap/js/bootstrap.min.js"></script>
 
@@ -14,7 +14,7 @@
 <body class="body">
 	<div id="f1body">
 		<section id="head" class="container" style="margin: 10px;">
-			<a href="index.html?v=6.904" class="voltar black"> <span
+			<a href="index.html?v=6.910" class="voltar black"> <span
 				class="glyphicon glyphicon glyphicon-chevron-left"
 				aria-hidden="true"></span>
 			</a>
@@ -83,14 +83,14 @@
 		</section>
 		<footer class="footer">
 			<div class="container">
-				<p>Build: 6.904</p>
+				<p>Build: 6.910</p>
 			</div>
 		</footer>
 	</div>
 </body>
-<script src="js/util.js?v=6.904"></script>
-<script src="js/loader.js?v=6.904"></script>
-<script src="js/lang.js?v=6.904"></script>
+<script src="js/util.js?v=6.910"></script>
+<script src="js/loader.js?v=6.910"></script>
+<script src="js/lang.js?v=6.910"></script>
 <script>
 $('#TIPO_PNEU_MOLE').html(lang_text('TIPO_PNEU_MOLE'));
 $('#TIPO_PNEU_DURO').html(lang_text('TIPO_PNEU_DURO'));

--- a/src/main/webapp/html5/corrida.html
+++ b/src/main/webapp/html5/corrida.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, maximum-scale=1, user-scalable=no">
 <script src="../jquery/jquery-3.2.1.min.js"></script>
-<link rel="stylesheet" href="css/flmane.css?v=6.904">
+<link rel="stylesheet" href="css/flmane.css?v=6.910">
 </head>
 <body id="body" style="width: 100%; height: 100%; margin: 0px; overflow: hidden" class="body">
 <canvas id="maneCanvas"></canvas>
@@ -12,13 +12,13 @@
 <img id="imgJog1" class="userPic"/>
 <img id="imgJog2" class="userPic"/>
 </body>
-<script src="js/util.js?v=6.904"></script>
-<script src="js/lang.js?v=6.904"></script>
-<script src="js/geo.js?v=6.904"></script>
-<script src="js/fps.js?v=6.904"></script>
-<script src="js/vdp.js?v=6.904"></script>
-<script src="js/ctl.js?v=6.904"></script>
-<script src="js/rest.js?v=6.904"></script>
-<script src="js/mid.js?v=6.904"></script>
-<script src="js/cpu.js?v=6.904"></script>
+<script src="js/util.js?v=6.910"></script>
+<script src="js/lang.js?v=6.910"></script>
+<script src="js/geo.js?v=6.910"></script>
+<script src="js/fps.js?v=6.910"></script>
+<script src="js/vdp.js?v=6.910"></script>
+<script src="js/ctl.js?v=6.910"></script>
+<script src="js/rest.js?v=6.910"></script>
+<script src="js/mid.js?v=6.910"></script>
+<script src="js/cpu.js?v=6.910"></script>
 </html>

--- a/src/main/webapp/html5/equipe.html
+++ b/src/main/webapp/html5/equipe.html
@@ -5,7 +5,7 @@
 <meta name="viewport"
 	content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 <link rel="stylesheet" href="../bootstrap/css/bootstrap.min.css">
-<link rel="stylesheet" href="css/flmane.css?v=6.904">
+<link rel="stylesheet" href="css/flmane.css?v=6.910">
 <script src="../jquery/jquery-3.2.1.min.js"></script>
 <script src="../bootstrap/js/bootstrap.min.js"></script>
 
@@ -14,7 +14,7 @@
 <body class="body">
 	<div id="f1body">
 		<section id="head" class="container" style="margin: 10px;">
-			<a href="index.html?v=6.904" id="voltar" class="voltar black"> <span
+			<a href="index.html?v=6.910" id="voltar" class="voltar black"> <span
 				class="glyphicon glyphicon glyphicon-chevron-left"
 				aria-hidden="true"></span>
 			</a>
@@ -189,13 +189,13 @@
 		</section>
 		<footer class="footer">
 			<div class="container">
-				<p>Build: 6.904</p>
+				<p>Build: 6.910</p>
 			</div>
 		</footer>
 	</div>
 </body>
-<script src="js/util.js?v=6.904"></script>
-<script src="js/loader.js?v=6.904"></script>
-<script src="js/lang.js?v=6.904"></script>
-<script src="js/equipe.js?v=6.904"></script>
+<script src="js/util.js?v=6.910"></script>
+<script src="js/loader.js?v=6.910"></script>
+<script src="js/lang.js?v=6.910"></script>
+<script src="js/equipe.js?v=6.910"></script>
 </html>

--- a/src/main/webapp/html5/index.html
+++ b/src/main/webapp/html5/index.html
@@ -4,8 +4,8 @@
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 	<link rel="stylesheet" href="../bootstrap/css/bootstrap.min.css">
-	<link rel="stylesheet" href="css/flmane.css?v=6.904">
-	<link rel="stylesheet" href="css/mdb-btns.css?v=6.904">
+	<link rel="stylesheet" href="css/flmane.css?v=6.910">
+	<link rel="stylesheet" href="css/mdb-btns.css?v=6.910">
 	<script src="../jquery/jquery-3.2.1.min.js"></script>
 	<script src="../jwtdecode/jwt-decode.js"></script>
 	<!--  <script src="https://accounts.google.com/gsi/client" async defer></script> -->
@@ -43,14 +43,14 @@
 						maxlength="30"
 				/>
 			</div>
-			<a href="jogar.html?v=6.904" class="list-group-item transparent">
+			<a href="jogar.html?v=6.910" class="list-group-item transparent">
 				<button type="button" id="btnJogar" class="btn btn-default btn-block btn-raised bgTransparent"></button>
 			</a>
-			<a href="classificacao.html?v=6.904" class="list-group-item transparent">
+			<a href="classificacao.html?v=6.910" class="list-group-item transparent">
 				<button type="button" id="btnClassificacao"
 						class="btn btn-default btn-block btn-raised bgTransparent"></button>
 			</a>
-			<a href="equipe.html?v=6.904" class="list-group-item transparent ">
+			<a href="equipe.html?v=6.910" class="list-group-item transparent ">
 				<button type="button" id="btnEquipe"
 						class="btn btn-default btn-block btn-raised bgTransparent"></button>
 			</a>
@@ -58,11 +58,11 @@
 				<button type="button" id="btnCampeonato"
 						class="btn btn-default btn-block btn-raised bgTransparent"></button>
 			</a>
-			<a href="controles.html?v=6.904" class="list-group-item transparent">
+			<a href="controles.html?v=6.910" class="list-group-item transparent">
 				<button type="button" id="btnControles"
 						class="btn btn-default btn-block btn-raised bgTransparent"></button>
 			</a>
-			<a href="configuracao.html?v=6.904" class="list-group-item transparent">
+			<a href="configuracao.html?v=6.910" class="list-group-item transparent">
 				<button type="button" id="btnConfiguracao"
 						class="btn btn-default btn-block btn-raised bgTransparent"></button>
 			</a>
@@ -77,14 +77,14 @@
 	</section>
 	<footer class="footer">
 		<div class="container">
-			<p>Build: 6.904</p>
-			<input id="versao" type="hidden" value="6.904"/>
+			<p>Build: 6.910</p>
+			<input id="versao" type="hidden" value="6.910"/>
 		</div>
 	</footer>
 </div>
 </body>
-<script src="js/util.js?v=6.904"></script>
-<script src="js/loader.js?v=6.904"></script>
-<script src="js/lang.js?v=6.904"></script>
-<script src="js/index.js?v=6.904"></script>
+<script src="js/util.js?v=6.910"></script>
+<script src="js/loader.js?v=6.910"></script>
+<script src="js/lang.js?v=6.910"></script>
+<script src="js/index.js?v=6.910"></script>
 </html>

--- a/src/main/webapp/html5/jogar.html
+++ b/src/main/webapp/html5/jogar.html
@@ -5,7 +5,7 @@
 <meta name="viewport"
 	content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 <link rel="stylesheet" href="../bootstrap/css/bootstrap.min.css">
-<link rel="stylesheet" href="css/flmane.css?v=6.904">
+<link rel="stylesheet" href="css/flmane.css?v=6.910">
 <script src="../jquery/jquery-3.2.1.min.js"></script>
 <script src="../bootstrap/js/bootstrap.min.js"></script>
 
@@ -14,7 +14,7 @@
 <body class="body">
 <div id="f1body">
 	<section id="head" class="container" style="margin: 10px;">
-        <a href="index.html?v=6.904" id="voltar" class="voltar black">
+        <a href="index.html?v=6.910" id="voltar" class="voltar black">
           <span class="glyphicon glyphicon glyphicon-chevron-left" aria-hidden="true"></span> 
         </a>
 		<h3 style="display: inline;">Fl-Mane</h3>
@@ -193,13 +193,13 @@
 	</section>
 	<footer class="footer">
 		<div class="container">
-			<p>Build: 6.904</p>
+			<p>Build: 6.910</p>
 		</div>
 	</footer>
 </div>	
 </body>
-<script src="js/util.js?v=6.904"></script>
-<script src="js/loader.js?v=6.904"></script>
-<script src="js/lang.js?v=6.904"></script>
-<script src="js/jogar.js?v=6.904"></script>
+<script src="js/util.js?v=6.910"></script>
+<script src="js/loader.js?v=6.910"></script>
+<script src="js/lang.js?v=6.910"></script>
+<script src="js/jogar.js?v=6.910"></script>
 </html>

--- a/src/main/webapp/html5/resultado.html
+++ b/src/main/webapp/html5/resultado.html
@@ -10,7 +10,7 @@
 </head>
 <body class="body">
 	<section id="head" class="container" style="margin: 10px;">
-        <a href="index.html?v=6.904" class="voltar black">
+        <a href="index.html?v=6.910" class="voltar black">
           <span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span> 
         </a>
 		<h3 style="display: inline;">Fl-Mane</h3>
@@ -86,12 +86,12 @@
 	</section>
 	<footer class="footer">
 		<div class="container">
-			<p >Build: 6.904</p>
+			<p >Build: 6.910</p>
 		</div>
 	</footer>
 </body>
-<script src="js/loader.js?v=6.904"></script>
-<script src="js/util.js?v=6.904"></script>
-<script src="js/lang.js?v=6.904"></script>
-<script src="js/resultado.js?v=6.904"></script>
+<script src="js/loader.js?v=6.910"></script>
+<script src="js/util.js?v=6.910"></script>
+<script src="js/lang.js?v=6.910"></script>
+<script src="js/resultado.js?v=6.910"></script>
 </html>

--- a/src/test/java/br/f1mane/servidor/controles/ControleCampeonatoServidorTest.java
+++ b/src/test/java/br/f1mane/servidor/controles/ControleCampeonatoServidorTest.java
@@ -1,0 +1,308 @@
+package br.f1mane.servidor.controles;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hibernate.Session;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import br.f1mane.entidades.TemporadasDefault;
+import br.f1mane.recursos.CarregadorRecursos;
+import br.f1mane.servidor.entidades.TOs.CampeonatoTO;
+import br.f1mane.servidor.entidades.TOs.ClientPaddockPack;
+import br.f1mane.servidor.entidades.TOs.ErroServ;
+import br.f1mane.servidor.entidades.TOs.MsgSrv;
+import br.f1mane.servidor.entidades.TOs.SessaoCliente;
+import br.f1mane.servidor.entidades.persistencia.CampeonatoSrv;
+import br.f1mane.servidor.entidades.persistencia.CorridaCampeonatoSrv;
+import br.f1mane.servidor.entidades.persistencia.JogadorDadosSrv;
+
+import java.util.Map;
+
+/**
+ * Cobre o ciclo de vida de campeonato em ControleCampeonatoServidor.
+ * ControlePersistencia, ControlePaddockServidor e CarregadorRecursos são
+ * mockados via o construtor pacote-privado de injeção; nenhum banco real
+ * nem classpath real é tocado.
+ */
+class ControleCampeonatoServidorTest {
+
+    private ControlePersistencia controlePersistencia;
+    private CarregadorRecursos carregadorRecursos;
+    private ControleCampeonatoServidor controleCampeonatoServidor;
+
+    @BeforeEach
+    void setUp() {
+        controlePersistencia = mock(ControlePersistencia.class);
+        carregadorRecursos = mock(CarregadorRecursos.class);
+        ControlePaddockServidor controlePaddockServidor = mock(ControlePaddockServidor.class);
+        controleCampeonatoServidor = new ControleCampeonatoServidor(controlePersistencia, controlePaddockServidor,
+                carregadorRecursos);
+    }
+
+    private CampeonatoSrv campeonatoComCorridas(int qtdeCorridas) {
+        CampeonatoSrv campeonato = new CampeonatoSrv();
+        campeonato.setNome("Campeonato Teste");
+        campeonato.setIdPiloto("piloto1");
+        List<CorridaCampeonatoSrv> corridas = new ArrayList<>();
+        for (int i = 0; i < qtdeCorridas; i++) {
+            corridas.add(new CorridaCampeonatoSrv());
+        }
+        campeonato.setCorridaCampeonatos(corridas);
+        return campeonato;
+    }
+
+    // ---- criarCampeonato(ClientPaddockPack): exige sessão de cliente ----
+
+    @Test
+    void criarCampeonato_sessaoNula_retornaMsgSrvSemPersistir() {
+        ClientPaddockPack clientPaddockPack = new ClientPaddockPack();
+
+        Object resultado = controleCampeonatoServidor.criarCampeonato(clientPaddockPack);
+
+        assertTrue(resultado instanceof MsgSrv);
+        verifyNenhumaPersistencia();
+    }
+
+    // ---- criarCampeonato(CampeonatoSrv, idUsuario): validações de entrada ----
+
+    @Test
+    void criarCampeonato_idUsuarioNulo_retornaMsgSrv() {
+        Object resultado = controleCampeonatoServidor.criarCampeonato(campeonatoComCorridas(5), null);
+
+        assertTrue(resultado instanceof MsgSrv);
+        verifyNenhumaPersistencia();
+    }
+
+    @Test
+    void criarCampeonato_nomeVazio_retornaMsgSrv() {
+        CampeonatoSrv campeonato = campeonatoComCorridas(5);
+        campeonato.setNome("");
+
+        Object resultado = controleCampeonatoServidor.criarCampeonato(campeonato, "usuario1");
+
+        assertTrue(resultado instanceof MsgSrv);
+        verifyNenhumaPersistencia();
+    }
+
+    @Test
+    void criarCampeonato_semPilotoSelecionado_retornaMsgSrv() {
+        CampeonatoSrv campeonato = campeonatoComCorridas(5);
+        campeonato.setIdPiloto(null);
+
+        Object resultado = controleCampeonatoServidor.criarCampeonato(campeonato, "usuario1");
+
+        assertTrue(resultado instanceof MsgSrv);
+        verifyNenhumaPersistencia();
+    }
+
+    @Test
+    void criarCampeonato_menosDe5Corridas_retornaMsgSrv() {
+        Object resultado = controleCampeonatoServidor.criarCampeonato(campeonatoComCorridas(4), "usuario1");
+
+        assertTrue(resultado instanceof MsgSrv);
+        verifyNenhumaPersistencia();
+    }
+
+    @Test
+    void criarCampeonato_jogadorJaTemCampeonatoEmAberto_retornaMsgSrvSemGravar() throws Exception {
+        Session session = mock(Session.class);
+        when(session.isOpen()).thenReturn(true);
+        when(controlePersistencia.getSession()).thenReturn(session);
+        when(controlePersistencia.pesquisaCampeonatosEmAberto(eq("usuario1"), any(Session.class), eq(false)))
+                .thenReturn(List.of(new CampeonatoSrv()));
+
+        Object resultado = controleCampeonatoServidor.criarCampeonato(campeonatoComCorridas(5), "usuario1");
+
+        assertTrue(resultado instanceof MsgSrv);
+        verify(controlePersistencia, never()).gravarDados(any(), any());
+    }
+
+    @Test
+    void criarCampeonato_nomeJaExistente_retornaMsgSrvSemGravar() throws Exception {
+        Session session = mock(Session.class);
+        when(session.isOpen()).thenReturn(true);
+        when(controlePersistencia.getSession()).thenReturn(session);
+        when(controlePersistencia.pesquisaCampeonatosEmAberto(eq("usuario1"), any(Session.class), eq(false)))
+                .thenReturn(List.of());
+        when(controlePersistencia.existeNomeCampeonato(any(Session.class), eq("Campeonato Teste")))
+                .thenReturn(true);
+
+        Object resultado = controleCampeonatoServidor.criarCampeonato(campeonatoComCorridas(5), "usuario1");
+
+        assertTrue(resultado instanceof MsgSrv);
+        verify(controlePersistencia, never()).gravarDados(any(), any());
+    }
+
+    @Test
+    void criarCampeonato_jogadorNaoEncontrado_retornaMsgSrvSemGravar() throws Exception {
+        Session session = mock(Session.class);
+        when(session.isOpen()).thenReturn(true);
+        when(controlePersistencia.getSession()).thenReturn(session);
+        when(controlePersistencia.pesquisaCampeonatosEmAberto(eq("usuario1"), any(Session.class), eq(false)))
+                .thenReturn(List.of());
+        when(controlePersistencia.existeNomeCampeonato(any(Session.class), eq("Campeonato Teste")))
+                .thenReturn(false);
+        when(controlePersistencia.carregaDadosJogador(eq("usuario1"), any(Session.class)))
+                .thenReturn(null);
+
+        Object resultado = controleCampeonatoServidor.criarCampeonato(campeonatoComCorridas(5), "usuario1");
+
+        assertTrue(resultado instanceof MsgSrv);
+        verify(controlePersistencia, never()).gravarDados(any(), any());
+    }
+
+    private void verifyNenhumaPersistencia() {
+        try {
+            verify(controlePersistencia, never()).getSession();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    // ---- verificaCampeonatoConcluido: pura ----
+
+    @Test
+    void verificaCampeonatoConcluido_todasCorridasComTempoFim_retornaTrue() {
+        CampeonatoSrv campeonato = new CampeonatoSrv();
+        CorridaCampeonatoSrv corrida1 = new CorridaCampeonatoSrv();
+        corrida1.setTempoFim(1000L);
+        CorridaCampeonatoSrv corrida2 = new CorridaCampeonatoSrv();
+        corrida2.setTempoFim(2000L);
+        campeonato.setCorridaCampeonatos(List.of(corrida1, corrida2));
+
+        assertTrue(controleCampeonatoServidor.verificaCampeonatoConcluido(campeonato));
+    }
+
+    @Test
+    void verificaCampeonatoConcluido_corridaSemTempoFim_retornaFalse() {
+        CampeonatoSrv campeonato = new CampeonatoSrv();
+        CorridaCampeonatoSrv corrida1 = new CorridaCampeonatoSrv();
+        corrida1.setTempoFim(1000L);
+        CorridaCampeonatoSrv corrida2 = new CorridaCampeonatoSrv();
+        corrida2.setTempoFim(null);
+        campeonato.setCorridaCampeonatos(List.of(corrida1, corrida2));
+
+        assertFalse(controleCampeonatoServidor.verificaCampeonatoConcluido(campeonato));
+    }
+
+    // ---- finalizaCampeonato ----
+
+    @Test
+    void finalizaCampeonato_semCampeonatoEmAberto_retornaNull() throws Exception {
+        Session session = mock(Session.class);
+        when(session.isOpen()).thenReturn(true);
+        when(controlePersistencia.getSession()).thenReturn(session);
+        when(controlePersistencia.pesquisaCampeonatosEmAberto(eq("usuario1"), any(Session.class), eq(false)))
+                .thenReturn(List.of());
+        CampeonatoTO campeonatoTO = new CampeonatoTO();
+        campeonatoTO.setId(1);
+
+        Object resultado = controleCampeonatoServidor.finalizaCampeonato(campeonatoTO, "usuario1");
+
+        assertNull(resultado);
+        verify(controlePersistencia, never()).gravarDados(any(), any());
+    }
+
+    @Test
+    void finalizaCampeonato_idDiferenteDoCampeonatoEmAberto_retornaNull() throws Exception {
+        Session session = mock(Session.class);
+        when(session.isOpen()).thenReturn(true);
+        when(controlePersistencia.getSession()).thenReturn(session);
+        CampeonatoSrv campeonatoEmAberto = mock(CampeonatoSrv.class);
+        when(campeonatoEmAberto.getId()).thenReturn(99L);
+        when(controlePersistencia.pesquisaCampeonatosEmAberto(eq("usuario1"), any(Session.class), eq(false)))
+                .thenReturn(List.of(campeonatoEmAberto));
+        CampeonatoTO campeonatoTO = new CampeonatoTO();
+        campeonatoTO.setId(1);
+
+        Object resultado = controleCampeonatoServidor.finalizaCampeonato(campeonatoTO, "usuario1");
+
+        assertNull(resultado);
+        verify(controlePersistencia, never()).gravarDados(any(), any());
+    }
+
+    @Test
+    void finalizaCampeonato_idCorrespondente_marcaFinalizadoEGrava() throws Exception {
+        Session session = mock(Session.class);
+        when(session.isOpen()).thenReturn(true);
+        when(controlePersistencia.getSession()).thenReturn(session);
+        CampeonatoSrv campeonatoEmAberto = mock(CampeonatoSrv.class);
+        when(campeonatoEmAberto.getId()).thenReturn(1L);
+        when(controlePersistencia.pesquisaCampeonatosEmAberto(eq("usuario1"), any(Session.class), eq(false)))
+                .thenReturn(List.of(campeonatoEmAberto));
+        CampeonatoTO campeonatoTO = new CampeonatoTO();
+        campeonatoTO.setId(1);
+
+        Object resultado = controleCampeonatoServidor.finalizaCampeonato(campeonatoTO, "usuario1");
+
+        assertEquals(campeonatoTO, resultado);
+        verify(campeonatoEmAberto).setFinalizado(true);
+        verify(controlePersistencia).gravarDados(eq(session), eq(campeonatoEmAberto));
+    }
+
+    @Test
+    void finalizaCampeonato_excecaoNaPersistencia_retornaErroServ() throws Exception {
+        Session session = mock(Session.class);
+        when(session.isOpen()).thenReturn(true);
+        when(controlePersistencia.getSession()).thenReturn(session);
+        when(controlePersistencia.pesquisaCampeonatosEmAberto(eq("usuario1"), any(Session.class), eq(false)))
+                .thenThrow(new RuntimeException("falha de banco"));
+        CampeonatoTO campeonatoTO = new CampeonatoTO();
+        campeonatoTO.setId(1);
+
+        Object resultado = controleCampeonatoServidor.finalizaCampeonato(campeonatoTO, "usuario1");
+
+        assertTrue(resultado instanceof ErroServ);
+    }
+
+    // ---- criarCampeonato: caminho de sucesso completo, com CarregadorRecursos mockado ----
+
+    @Test
+    void criarCampeonato_dadosValidos_gravaERetornaSucesso() throws Exception {
+        Session session = mock(Session.class);
+        when(session.isOpen()).thenReturn(true);
+        when(controlePersistencia.getSession()).thenReturn(session);
+        when(controlePersistencia.pesquisaCampeonatosEmAberto(eq("usuario1"), any(Session.class), eq(false)))
+                .thenReturn(List.of());
+        when(controlePersistencia.existeNomeCampeonato(any(Session.class), eq("Campeonato Teste")))
+                .thenReturn(false);
+        JogadorDadosSrv jogadorDadosSrv = mock(JogadorDadosSrv.class);
+        when(controlePersistencia.carregaDadosJogador(eq("usuario1"), any(Session.class)))
+                .thenReturn(jogadorDadosSrv);
+        when(controlePersistencia.pesquisaCampeonatos(eq(jogadorDadosSrv), any(Session.class)))
+                .thenReturn(List.of());
+
+        TemporadasDefault temporadasDefault = new TemporadasDefault();
+        temporadasDefault.setTrocaPneu(true);
+        temporadasDefault.setDrs(true);
+        temporadasDefault.setErs(false);
+        temporadasDefault.setReabastecimento(true);
+        when(carregadorRecursos.carregarTemporadasPilotosDefauts())
+                .thenReturn(Map.of("t2024", temporadasDefault));
+
+        CampeonatoSrv campeonato = campeonatoComCorridas(5);
+        campeonato.setTemporada("2024");
+
+        Object resultado = controleCampeonatoServidor.criarCampeonato(campeonato, "usuario1");
+
+        assertTrue(campeonato.isTrocaPneus());
+        assertTrue(campeonato.isDrs());
+        assertFalse(campeonato.isErs());
+        assertEquals(jogadorDadosSrv, campeonato.getJogadorDadosSrv());
+        verify(controlePersistencia).gravarDados(eq(session), eq(campeonato));
+        assertTrue(resultado instanceof MsgSrv);
+    }
+}

--- a/src/test/java/br/f1mane/servidor/controles/ControleClassificacaoTest.java
+++ b/src/test/java/br/f1mane/servidor/controles/ControleClassificacaoTest.java
@@ -1,0 +1,276 @@
+package br.f1mane.servidor.controles;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.hibernate.Session;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import br.f1mane.entidades.Carro;
+import br.f1mane.entidades.Piloto;
+import br.f1mane.recursos.CarregadorRecursos;
+import br.f1mane.servidor.entidades.TOs.ErroServ;
+import br.f1mane.servidor.entidades.TOs.MsgSrv;
+import br.f1mane.servidor.entidades.persistencia.CarreiraDadosSrv;
+import br.f1mane.servidor.entidades.persistencia.JogadorDadosSrv;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Cobre as regras de pontuação e validação de carreira de ControleClassificacao.
+ * ControlePersistencia e CarregadorRecursos são mockados via o construtor
+ * pacote-privado de injeção; nenhum banco real nem classpath real é tocado.
+ */
+class ControleClassificacaoTest {
+
+    private ControlePersistencia controlePersistencia;
+    private CarregadorRecursos carregadorRecursos;
+    private ControleClassificacao controleClassificacao;
+
+    @BeforeEach
+    void setUp() {
+        controlePersistencia = mock(ControlePersistencia.class);
+        carregadorRecursos = mock(CarregadorRecursos.class);
+        ControleCampeonatoServidor controleCampeonatoServidor = mock(ControleCampeonatoServidor.class);
+        controleClassificacao = new ControleClassificacao(controlePersistencia, controleCampeonatoServidor,
+                carregadorRecursos);
+    }
+
+    private Piloto pilotoNaPosicao(int posicao) {
+        Piloto piloto = new Piloto();
+        piloto.setPosicao(posicao);
+        return piloto;
+    }
+
+    // ---- gerarPontos: tabela de pontuação por posição ----
+
+    @ParameterizedTest(name = "posicao {0} vale {1} pontos")
+    @CsvSource({
+            "1, 25", "2, 18", "3, 15", "4, 12", "5, 10",
+            "6, 8", "7, 6", "8, 4", "9, 2", "10, 1",
+            "11, 0", "20, 0"
+    })
+    void gerarPontos_seguePorPosicao(int posicao, int pontosEsperados) {
+        assertEquals(pontosEsperados, controleClassificacao.gerarPontos(pilotoNaPosicao(posicao)));
+    }
+
+    // ---- validadeDistribuicaoPontos: orquestra Util.processaValorPontosCarreira ----
+
+    private CarreiraDadosSrv carreiraComBase(int construtores, int aero, int carro, int freio, int piloto) {
+        CarreiraDadosSrv carreiraDadosSrv = new CarreiraDadosSrv();
+        carreiraDadosSrv.setPtsConstrutores(construtores);
+        carreiraDadosSrv.setPtsAerodinamica(aero);
+        carreiraDadosSrv.setPtsCarro(carro);
+        carreiraDadosSrv.setPtsFreio(freio);
+        carreiraDadosSrv.setPtsPiloto(piloto);
+        return carreiraDadosSrv;
+    }
+
+    @Test
+    void validadeDistribuicaoPontos_upgradeUnico_debitaCustoDaFaixa() {
+        CarreiraDadosSrv base = carreiraComBase(1000, 100, 100, 100, 100);
+
+        int saldo = ControleClassificacao.validadeDistribuicaoPontos(base, 101, 100, 100, 100);
+
+        assertEquals(999, saldo);
+    }
+
+    @Test
+    void validadeDistribuicaoPontos_downgradeUnico_creditaRefundDaFaixa() {
+        CarreiraDadosSrv base = carreiraComBase(1000, 100, 100, 100, 100);
+
+        int saldo = ControleClassificacao.validadeDistribuicaoPontos(base, 99, 100, 100, 100);
+
+        assertEquals(1001, saldo);
+    }
+
+    @Test
+    void validadeDistribuicaoPontos_mudancaSimultaneaEmMultiplosAtributos_somaCustosERefunds() {
+        // aerodinamica sobe 1 (custo 1), carro sobe 1 (custo 1), freio desce 1 (refund 1)
+        CarreiraDadosSrv base = carreiraComBase(1000, 100, 100, 100, 100);
+
+        int saldo = ControleClassificacao.validadeDistribuicaoPontos(base, 101, 101, 99, 100);
+
+        assertEquals(1000 - 1 - 1 + 1, saldo);
+    }
+
+    @Test
+    void validadeDistribuicaoPontos_upgrade998Para999_debita50Pontos() {
+        CarreiraDadosSrv base = carreiraComBase(1000, 998, 100, 100, 100);
+
+        int saldo = ControleClassificacao.validadeDistribuicaoPontos(base, 999, 100, 100, 100);
+
+        assertEquals(950, saldo);
+    }
+
+    // ---- atualizaCarreira: validação antes de gravar ----
+
+    private CarreiraDadosSrv carreiraValida() {
+        CarreiraDadosSrv carreiraDados = new CarreiraDadosSrv();
+        carreiraDados.setNomeCarro("Carro Teste");
+        carreiraDados.setNomePiloto("Piloto Teste");
+        carreiraDados.setNomePilotoAbreviado("PTE");
+        carreiraDados.setPtsAerodinamica(100);
+        carreiraDados.setPtsCarro(100);
+        carreiraDados.setPtsFreio(100);
+        carreiraDados.setPtsPiloto(100);
+        return carreiraDados;
+    }
+
+    private void stubCarreiraExistente(int construtoresBase) {
+        CarreiraDadosSrv carreiraExistente = carreiraComBase(construtoresBase, 100, 100, 100, 100);
+        JogadorDadosSrv jogadorDadosSrv = mock(JogadorDadosSrv.class);
+        when(jogadorDadosSrv.getId()).thenReturn(1L);
+        carreiraExistente.setJogadorDadosSrv(jogadorDadosSrv);
+        Session session = mock(Session.class);
+        when(session.isOpen()).thenReturn(true);
+        when(controlePersistencia.getSession()).thenReturn(session);
+        when(controlePersistencia.carregaCarreiraJogador(eq("usuario1"), eq(false), any(Session.class)))
+                .thenReturn(carreiraExistente);
+    }
+
+    @Test
+    void atualizaCarreira_nomeCarroVazio_retornaMsgSrvSemGravar() throws Exception {
+        stubCarreiraExistente(1000);
+        CarreiraDadosSrv carreiraDados = carreiraValida();
+        carreiraDados.setNomeCarro("");
+
+        Object resultado = controleClassificacao.atualizaCarreira("usuario1", carreiraDados);
+
+        assertTrue(resultado instanceof MsgSrv);
+        verify(controlePersistencia, never()).gravarDados(any(), any());
+    }
+
+    @Test
+    void atualizaCarreira_nomeCarroMuitoLongo_retornaMsgSrvSemGravar() throws Exception {
+        stubCarreiraExistente(1000);
+        CarreiraDadosSrv carreiraDados = carreiraValida();
+        carreiraDados.setNomeCarro("Um Nome De Carro Com Mais De Vinte Caracteres");
+
+        Object resultado = controleClassificacao.atualizaCarreira("usuario1", carreiraDados);
+
+        assertTrue(resultado instanceof MsgSrv);
+        verify(controlePersistencia, never()).gravarDados(any(), any());
+    }
+
+    @Test
+    void atualizaCarreira_nomeCarroDuplicado_retornaMsgSrvSemGravar() throws Exception {
+        stubCarreiraExistente(1000);
+        when(controlePersistencia.existeNomeCarro(any(Session.class), eq("Carro Teste"), anyLong()))
+                .thenReturn(true);
+
+        Object resultado = controleClassificacao.atualizaCarreira("usuario1", carreiraValida());
+
+        assertTrue(resultado instanceof MsgSrv);
+        verify(controlePersistencia, never()).gravarDados(any(), any());
+    }
+
+    @Test
+    void atualizaCarreira_nomePilotoDuplicado_retornaMsgSrvSemGravar() throws Exception {
+        stubCarreiraExistente(1000);
+        when(controlePersistencia.existeNomePiloto(any(Session.class), eq("Piloto Teste"), anyLong()))
+                .thenReturn(true);
+
+        Object resultado = controleClassificacao.atualizaCarreira("usuario1", carreiraValida());
+
+        assertTrue(resultado instanceof MsgSrv);
+        verify(controlePersistencia, never()).gravarDados(any(), any());
+    }
+
+    @Test
+    void atualizaCarreira_dadosValidos_gravaERetornaSucesso() throws Exception {
+        stubCarreiraExistente(1000);
+        when(controlePersistencia.existeNomeCarro(any(Session.class), any(), anyLong())).thenReturn(false);
+        when(controlePersistencia.existeNomePiloto(any(Session.class), any(), anyLong())).thenReturn(false);
+
+        Object resultado = controleClassificacao.atualizaCarreira("usuario1", carreiraValida());
+
+        verify(controlePersistencia).gravarDados(any(Session.class), any(CarreiraDadosSrv.class));
+        assertFalse(resultado instanceof ErroServ);
+    }
+
+    // ---- atualizaCarreira: validação de livery/capacete (CarregadorRecursos mockado) ----
+
+    private Piloto pilotoModeloComCarro(int id, int habilidadeReal, int carroId, int potenciaReal, int aerodinamica,
+                                        int freios) {
+        Piloto piloto = new Piloto();
+        piloto.setId(id);
+        piloto.setHabilidadeReal(habilidadeReal);
+        Carro carro = new Carro();
+        carro.setId(carroId);
+        carro.setPotenciaReal(potenciaReal);
+        carro.setAerodinamica(aerodinamica);
+        carro.setFreios(freios);
+        piloto.setCarro(carro);
+        return piloto;
+    }
+
+    @Test
+    void atualizaCarreira_capaceteDeNivelMaisAltoQueOJogador_retornaMsgSrvSemGravar() throws Exception {
+        stubCarreiraExistente(1000);
+        when(controlePersistencia.existeNomeCarro(any(Session.class), any(), anyLong())).thenReturn(false);
+        when(controlePersistencia.existeNomePiloto(any(Session.class), any(), anyLong())).thenReturn(false);
+        Piloto pilotoModelo = pilotoModeloComCarro(5, 999, 1, 0, 0, 0);
+        when(carregadorRecursos.carregarTemporadasPilotos()).thenReturn(Map.of("t2024", List.of(pilotoModelo)));
+
+        CarreiraDadosSrv carreiraDados = carreiraValida();
+        carreiraDados.setTemporadaCapaceteLivery(2024);
+        carreiraDados.setIdCapaceteLivery(5);
+        carreiraDados.setPtsPiloto(100); // muito abaixo da habilidadeReal (999) do piloto modelo
+
+        Object resultado = controleClassificacao.atualizaCarreira("usuario1", carreiraDados);
+
+        assertTrue(resultado instanceof MsgSrv);
+        verify(controlePersistencia, never()).gravarDados(any(), any());
+    }
+
+    @Test
+    void atualizaCarreira_capaceteDeNivelCompativel_naoBloqueia() throws Exception {
+        stubCarreiraExistente(1000);
+        when(controlePersistencia.existeNomeCarro(any(Session.class), any(), anyLong())).thenReturn(false);
+        when(controlePersistencia.existeNomePiloto(any(Session.class), any(), anyLong())).thenReturn(false);
+        Piloto pilotoModelo = pilotoModeloComCarro(5, 50, 1, 0, 0, 0);
+        when(carregadorRecursos.carregarTemporadasPilotos()).thenReturn(Map.of("t2024", List.of(pilotoModelo)));
+
+        CarreiraDadosSrv carreiraDados = carreiraValida();
+        carreiraDados.setTemporadaCapaceteLivery(2024);
+        carreiraDados.setIdCapaceteLivery(5);
+        carreiraDados.setPtsPiloto(100); // igual ou acima da habilidadeReal (50) do piloto modelo
+
+        Object resultado = controleClassificacao.atualizaCarreira("usuario1", carreiraDados);
+
+        verify(controlePersistencia).gravarDados(any(Session.class), any(CarreiraDadosSrv.class));
+        assertFalse(resultado instanceof ErroServ);
+    }
+
+    @Test
+    void atualizaCarreira_carroDeNivelMaisAltoQueOJogador_retornaMsgSrvSemGravar() throws Exception {
+        stubCarreiraExistente(1000);
+        when(controlePersistencia.existeNomeCarro(any(Session.class), any(), anyLong())).thenReturn(false);
+        when(controlePersistencia.existeNomePiloto(any(Session.class), any(), anyLong())).thenReturn(false);
+        Piloto pilotoModelo = pilotoModeloComCarro(1, 0, 7, 999, 0, 0);
+        when(carregadorRecursos.carregarTemporadasPilotos()).thenReturn(Map.of("t2024", List.of(pilotoModelo)));
+
+        CarreiraDadosSrv carreiraDados = carreiraValida();
+        carreiraDados.setTemporadaCarroLivery(2024);
+        carreiraDados.setIdCarroLivery(7);
+        carreiraDados.setPtsCarro(100); // muito abaixo da potenciaReal (999) do carro modelo
+
+        Object resultado = controleClassificacao.atualizaCarreira("usuario1", carreiraDados);
+
+        assertTrue(resultado instanceof MsgSrv);
+        verify(controlePersistencia, never()).gravarDados(any(), any());
+    }
+}

--- a/src/test/java/br/f1mane/servidor/controles/ControleJogosServerTest.java
+++ b/src/test/java/br/f1mane/servidor/controles/ControleJogosServerTest.java
@@ -1,0 +1,148 @@
+package br.f1mane.servidor.controles;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import br.f1mane.entidades.Carro;
+import br.f1mane.entidades.Piloto;
+import br.f1mane.servidor.JogoServidor;
+import br.f1mane.servidor.entidades.TOs.DadosCriarJogo;
+import br.f1mane.servidor.entidades.TOs.SessaoCliente;
+
+/**
+ * Cobre os controles de pilotagem (giro de motor, agressividade, DRS/ERS,
+ * box) em ControleJogosServer, via obterPilotoPorId. JogoServidor é mockado;
+ * o "jogo em andamento" é simulado injetando diretamente no mapaJogosCriados.
+ */
+class ControleJogosServerTest {
+
+    private static final String ID_PILOTO = "7";
+    private static final String NOME_JOGO = "jogo1";
+
+    private ControleJogosServer controleJogosServer;
+    private SessaoCliente sessaoCliente;
+    private Piloto piloto;
+
+    @BeforeEach
+    void setUp() {
+        ControlePersistencia controlePersistencia = mock(ControlePersistencia.class);
+        ControleCampeonatoServidor controleCampeonatoServidor = mock(ControleCampeonatoServidor.class);
+        ControleClassificacao controleClassificacao = mock(ControleClassificacao.class);
+        ControlePaddockServidor controlePaddockServidor = mock(ControlePaddockServidor.class);
+        controleJogosServer = new ControleJogosServer(new br.f1mane.servidor.entidades.TOs.DadosPaddock(),
+                controleClassificacao, controleCampeonatoServidor, controlePersistencia, controlePaddockServidor);
+
+        sessaoCliente = new SessaoCliente();
+        sessaoCliente.setIdUsuario("usuario1");
+        sessaoCliente.setJogoAtual(NOME_JOGO);
+
+        piloto = new Piloto();
+        piloto.setId(7);
+        piloto.setCarro(new Carro());
+
+        registrarJogoComPiloto(sessaoCliente, piloto);
+    }
+
+    private void registrarJogoComPiloto(SessaoCliente sessao, Piloto pilotoDoJogo) {
+        JogoServidor jogoServidor = mock(JogoServidor.class);
+        when(jogoServidor.getNomeJogoServidor()).thenReturn(NOME_JOGO);
+        DadosCriarJogo dadosCriarJogo = mock(DadosCriarJogo.class);
+        when(dadosCriarJogo.getIdPiloto()).thenReturn(pilotoDoJogo.getId());
+        Map<String, DadosCriarJogo> mapJogadoresOnline = new HashMap<>();
+        mapJogadoresOnline.put(sessao.getIdUsuario(), dadosCriarJogo);
+        when(jogoServidor.getMapJogadoresOnline()).thenReturn(mapJogadoresOnline);
+        when(jogoServidor.getPilotos()).thenReturn(List.of(pilotoDoJogo));
+
+        Map<SessaoCliente, JogoServidor> mapaJogosCriados = new HashMap<>();
+        mapaJogosCriados.put(sessao, jogoServidor);
+        controleJogosServer.setMapaJogosCriados(mapaJogosCriados);
+    }
+
+    // ---- obterPilotoPorId: base de todos os controles de pilotagem ----
+
+    @Test
+    void obterPilotoPorId_pilotoRegistradoNoJogoAtual_retornaPiloto() {
+        assertEquals(piloto, controleJogosServer.obterPilotoPorId(sessaoCliente, ID_PILOTO));
+    }
+
+    @Test
+    void obterPilotoPorId_idPilotoNaoCorrespondeAoDaSessao_retornaNull() {
+        assertNull(controleJogosServer.obterPilotoPorId(sessaoCliente, "999"));
+    }
+
+    @Test
+    void obterPilotoPorId_sessaoSemJogoCorrespondente_retornaNull() {
+        sessaoCliente.setJogoAtual("outro-jogo");
+
+        assertNull(controleJogosServer.obterPilotoPorId(sessaoCliente, ID_PILOTO));
+    }
+
+    // ---- mudarGiroMotor ----
+
+    @Test
+    void mudarGiroMotor_pilotoValido_aplicaMudancaERetornaTrue() {
+        Boolean resultado = controleJogosServer.mudarGiroMotor(sessaoCliente, ID_PILOTO, Carro.GIRO_MAX);
+
+        assertTrue(resultado);
+        assertEquals(Carro.GIRO_MAX_VAL, piloto.getCarro().getGiro());
+        assertTrue(piloto.isAtivarDRS());
+    }
+
+    @Test
+    void mudarGiroMotor_pilotoInexistente_retornaNull() {
+        assertNull(controleJogosServer.mudarGiroMotor(sessaoCliente, "999", Carro.GIRO_MAX));
+    }
+
+    @Test
+    void mudarGiroMotor_mesmoGiroDeAntes_retornaFalse() {
+        // giro padrão já é GIRO_NOR
+        Boolean resultado = controleJogosServer.mudarGiroMotor(sessaoCliente, ID_PILOTO, Carro.GIRO_NOR);
+
+        assertFalse(resultado);
+    }
+
+    // ---- mudarAgressividadePiloto ----
+
+    @Test
+    void mudarAgressividadePiloto_valorValido_aplicaMudanca() {
+        Boolean resultado = controleJogosServer.mudarAgressividadePiloto(sessaoCliente, ID_PILOTO, Piloto.AGRESSIVO);
+
+        assertTrue(resultado);
+        assertEquals(Piloto.AGRESSIVO, piloto.getModoPilotagem());
+    }
+
+    @Test
+    void mudarAgressividadePiloto_valorInvalido_retornaFalseSemMudar() {
+        String modoAntes = piloto.getModoPilotagem();
+
+        Boolean resultado = controleJogosServer.mudarAgressividadePiloto(sessaoCliente, ID_PILOTO, "VALOR_INVALIDO");
+
+        assertFalse(resultado);
+        assertEquals(modoAntes, piloto.getModoPilotagem());
+    }
+
+    @Test
+    void mudarAgressividadePiloto_pilotoInexistente_retornaFalse() {
+        assertFalse(controleJogosServer.mudarAgressividadePiloto(sessaoCliente, "999", Piloto.AGRESSIVO));
+    }
+
+    // ---- boxPiloto: piloto inexistente não lança exceção ----
+
+    @Test
+    void boxPiloto_pilotoInexistente_retornaFalseSemExcecao() {
+        Object resultado = controleJogosServer.boxPiloto(sessaoCliente, "999", true, "MACIO", 50, Carro.ASA_NORMAL);
+
+        assertEquals(Boolean.FALSE, resultado);
+    }
+}

--- a/src/test/java/br/f1mane/servidor/controles/ControlePaddockServidorTest.java
+++ b/src/test/java/br/f1mane/servidor/controles/ControlePaddockServidorTest.java
@@ -1,0 +1,164 @@
+package br.f1mane.servidor.controles;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.hibernate.Session;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import br.f1mane.recursos.CarregadorRecursos;
+import br.f1mane.servidor.entidades.TOs.SessaoCliente;
+import br.f1mane.servidor.entidades.TOs.SrvPaddockPack;
+
+/**
+ * Cobre criação/renovação de sessão em ControlePaddockServidor.
+ * ControlePersistencia e CarregadorRecursos são mockados via o construtor
+ * pacote-privado de injeção; ControleClassificacao/ControleCampeonatoServidor/
+ * ControleJogosServer são as instâncias reais que o próprio construtor de
+ * ControlePaddockServidor monta (não são injetáveis separadamente), todas
+ * apontando para os mesmos mocks.
+ */
+class ControlePaddockServidorTest {
+
+    private ControlePersistencia controlePersistencia;
+    private ControlePaddockServidor controlePaddockServidor;
+
+    @BeforeEach
+    void setUp() {
+        controlePersistencia = mock(ControlePersistencia.class);
+        Session session = mock(Session.class);
+        when(session.isOpen()).thenReturn(true);
+        when(controlePersistencia.getSession()).thenReturn(session);
+        CarregadorRecursos carregadorRecursos = mock(CarregadorRecursos.class);
+        controlePaddockServidor = new ControlePaddockServidor(controlePersistencia, carregadorRecursos);
+    }
+
+    // ---- criarSessaoNome: reaproveita sessão existente vs. cria nova ----
+
+    @Test
+    void criarSessaoNome_usuarioNovo_criaSessaoComToken() {
+        Object resultado = controlePaddockServidor.criarSessaoNome("Piloto1");
+
+        assertTrue(resultado instanceof SrvPaddockPack);
+        SessaoCliente sessaoCliente = ((SrvPaddockPack) resultado).getSessaoCliente();
+        assertNotNull(sessaoCliente.getToken());
+        assertEquals("Piloto1", sessaoCliente.getIdUsuario());
+        assertEquals("Piloto1", sessaoCliente.getNomeJogador());
+        assertEquals(false, sessaoCliente.isGuest());
+    }
+
+    @Test
+    void criarSessaoNome_usuarioJaExistente_reaproveitaMesmaSessao() {
+        Object primeiraChamada = controlePaddockServidor.criarSessaoNome("Piloto1");
+        SessaoCliente primeiraSessao = ((SrvPaddockPack) primeiraChamada).getSessaoCliente();
+
+        Object segundaChamada = controlePaddockServidor.criarSessaoNome("Piloto1");
+        SessaoCliente segundaSessao = ((SrvPaddockPack) segundaChamada).getSessaoCliente();
+
+        assertSame(primeiraSessao, segundaSessao);
+        assertEquals(primeiraSessao.getToken(), segundaSessao.getToken());
+        assertEquals(1, controlePaddockServidor.getDadosPaddock().getClientes().size());
+    }
+
+    @Test
+    void criarSessaoNome_doisUsuariosDiferentes_criaDuasSessoesDistintas() {
+        controlePaddockServidor.criarSessaoNome("Piloto1");
+        controlePaddockServidor.criarSessaoNome("Piloto2");
+
+        assertEquals(2, controlePaddockServidor.getDadosPaddock().getClientes().size());
+    }
+
+    // ---- criarSessaoVisitante ----
+
+    @Test
+    void criarSessaoVisitante_marcaSessaoComoGuest() {
+        Object resultado = controlePaddockServidor.criarSessaoVisitante();
+
+        assertTrue(resultado instanceof SrvPaddockPack);
+        SessaoCliente sessaoCliente = ((SrvPaddockPack) resultado).getSessaoCliente();
+        assertTrue(sessaoCliente.isGuest());
+        assertNotNull(sessaoCliente.getToken());
+    }
+
+    @Test
+    void criarSessaoVisitante_chamadasSucessivasGeramNomesDiferentes() {
+        SessaoCliente primeiro = ((SrvPaddockPack) controlePaddockServidor.criarSessaoVisitante()).getSessaoCliente();
+        SessaoCliente segundo = ((SrvPaddockPack) controlePaddockServidor.criarSessaoVisitante()).getSessaoCliente();
+
+        assertNotEquals(primeiro.getNomeJogador(), segundo.getNomeJogador());
+    }
+
+    // ---- criarSessaoGoogle ----
+
+    @Test
+    void criarSessaoGoogle_usuarioNovo_criaSessaoNaoGuest() {
+        Object resultado = controlePaddockServidor.criarSessaoGoogle("g-123", "Fulano", "url-foto", "fulano@email.com");
+
+        assertTrue(resultado instanceof SrvPaddockPack);
+        SessaoCliente sessaoCliente = ((SrvPaddockPack) resultado).getSessaoCliente();
+        assertEquals("g-123", sessaoCliente.getIdUsuario());
+        assertEquals("Fulano", sessaoCliente.getNomeJogador());
+        assertEquals(false, sessaoCliente.isGuest());
+    }
+
+    @Test
+    void criarSessaoGoogle_idGoogleJaExistente_atualizaDadosDaMesmaSessao() {
+        controlePaddockServidor.criarSessaoGoogle("g-123", "Fulano", "url-antiga", "fulano@email.com");
+
+        Object resultado = controlePaddockServidor.criarSessaoGoogle("g-123", "Fulano Atualizado", "url-nova", "novo@email.com");
+
+        SessaoCliente sessaoCliente = ((SrvPaddockPack) resultado).getSessaoCliente();
+        assertEquals("Fulano Atualizado", sessaoCliente.getNomeJogador());
+        assertEquals("url-nova", sessaoCliente.getImagemJogador());
+        assertEquals(1, controlePaddockServidor.getDadosPaddock().getClientes().size());
+    }
+
+    // ---- obterSessaoPorToken ----
+
+    @Test
+    void obterSessaoPorToken_tokenExistente_retornaSessao() {
+        SessaoCliente sessaoCriada = ((SrvPaddockPack) controlePaddockServidor.criarSessaoVisitante()).getSessaoCliente();
+
+        SessaoCliente encontrada = controlePaddockServidor.obterSessaoPorToken(sessaoCriada.getToken());
+
+        assertSame(sessaoCriada, encontrada);
+    }
+
+    @Test
+    void obterSessaoPorToken_tokenInexistente_retornaNull() {
+        assertNull(controlePaddockServidor.obterSessaoPorToken("token-que-nao-existe"));
+    }
+
+    // ---- renovarSessaoVisitante ----
+
+    @Test
+    void renovarSessaoVisitante_tokenExistente_geraNovoToken() {
+        SessaoCliente sessaoCriada = ((SrvPaddockPack) controlePaddockServidor.criarSessaoVisitante()).getSessaoCliente();
+        String tokenAntigo = sessaoCriada.getToken();
+
+        Object resultado = controlePaddockServidor.renovarSessaoVisitante(tokenAntigo);
+
+        assertTrue(resultado instanceof SrvPaddockPack);
+        SessaoCliente sessaoRenovada = ((SrvPaddockPack) resultado).getSessaoCliente();
+        assertNotEquals(tokenAntigo, sessaoRenovada.getToken());
+    }
+
+    @Test
+    void renovarSessaoVisitante_tokenInexistente_criaNovaSessaoVisitante() {
+        int totalAntes = controlePaddockServidor.getDadosPaddock().getClientes().size();
+
+        Object resultado = controlePaddockServidor.renovarSessaoVisitante("token-que-nao-existe");
+
+        assertTrue(resultado instanceof SrvPaddockPack);
+        assertTrue(((SrvPaddockPack) resultado).getSessaoCliente().isGuest());
+        assertEquals(totalAntes + 1, controlePaddockServidor.getDadosPaddock().getClientes().size());
+    }
+}

--- a/src/test/java/br/f1mane/servidor/controles/ControlePersistenciaTest.java
+++ b/src/test/java/br/f1mane/servidor/controles/ControlePersistenciaTest.java
@@ -1,0 +1,117 @@
+package br.f1mane.servidor.controles;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import org.hibernate.Session;
+import org.junit.jupiter.api.Test;
+
+import br.f1mane.entidades.Piloto;
+import br.f1mane.servidor.entidades.TOs.MsgSrv;
+import br.f1mane.servidor.entidades.persistencia.CarreiraDadosSrv;
+
+/**
+ * Cobre a lógica pura de ControlePersistencia. A maior parte da classe é
+ * wrapper de CRUD do Hibernate (HQL direto em cima de Session) sem
+ * ramificação de regra - fora de escopo aqui. carreiraDadosParaPiloto é pura
+ * (mapeamento de objeto) e modoCarreira tem validação real testável via spy,
+ * estubando apenas as chamadas que tocam Session/Hibernate.
+ */
+class ControlePersistenciaTest {
+
+    // ---- carreiraDadosParaPiloto: mapeamento puro de carreira para piloto ----
+
+    private CarreiraDadosSrv carreiraBasica() {
+        CarreiraDadosSrv carreiraDadosSrv = new CarreiraDadosSrv();
+        carreiraDadosSrv.setNomePiloto("Piloto Teste");
+        carreiraDadosSrv.setNomeCarro("Carro Teste");
+        carreiraDadosSrv.setPtsPiloto(700);
+        carreiraDadosSrv.setPtsAerodinamica(600);
+        carreiraDadosSrv.setPtsCarro(650);
+        carreiraDadosSrv.setPtsFreio(620);
+        carreiraDadosSrv.setPtsConstrutoresGanhos(123);
+        return carreiraDadosSrv;
+    }
+
+    @Test
+    void carreiraDadosParaPiloto_semLiveryDefinido_usaCorComoFallback() {
+        ControlePersistencia controlePersistencia = new ControlePersistencia(null, null);
+        CarreiraDadosSrv carreiraDadosSrv = carreiraBasica();
+        Piloto piloto = new Piloto();
+
+        controlePersistencia.carreiraDadosParaPiloto(carreiraDadosSrv, piloto);
+
+        assertEquals("Piloto Teste", piloto.getNome());
+        assertEquals("Carro Teste", piloto.getNomeCarro());
+        assertEquals(700, piloto.getHabilidade());
+        assertEquals(123, piloto.getPontosCorrida());
+        assertNotNull(piloto.getCarro());
+        assertEquals(600, piloto.getCarro().getAerodinamica());
+        assertEquals(650, piloto.getCarro().getPotencia());
+        assertEquals(620, piloto.getCarro().getFreios());
+        // sem temporada de livery definida, cai no fallback de cor gerada
+        assertNotNull(piloto.getTemporadaCapaceteLivery());
+        assertNotNull(piloto.getTemporadaCarroLivery());
+    }
+
+    @Test
+    void carreiraDadosParaPiloto_comLiveryDefinido_usaIdDaLivery() {
+        ControlePersistencia controlePersistencia = new ControlePersistencia(null, null);
+        CarreiraDadosSrv carreiraDadosSrv = carreiraBasica();
+        carreiraDadosSrv.setTemporadaCapaceteLivery(2024);
+        carreiraDadosSrv.setIdCapaceteLivery(5);
+        carreiraDadosSrv.setTemporadaCarroLivery(2024);
+        carreiraDadosSrv.setIdCarroLivery(7);
+        Piloto piloto = new Piloto();
+
+        controlePersistencia.carreiraDadosParaPiloto(carreiraDadosSrv, piloto);
+
+        assertEquals("2024", piloto.getTemporadaCapaceteLivery());
+        assertEquals("5", piloto.getIdCapaceteLivery());
+        assertEquals("2024", piloto.getTemporadaCarroLivery());
+        assertEquals("7", piloto.getIdCarroLivery());
+    }
+
+    // ---- modoCarreira: validação antes de gravar (spy para estubar chamadas internas) ----
+
+    @Test
+    void modoCarreira_ativandoComDadosIncompletos_retornaMsgSrvSemGravar() throws Exception {
+        ControlePersistencia controlePersistencia = spy(new ControlePersistencia(null, null));
+        Session session = mock(Session.class);
+        doReturn(session).when(controlePersistencia).getSession();
+        CarreiraDadosSrv carreiraDadosSrv = new CarreiraDadosSrv();
+        carreiraDadosSrv.setNomeCarro("");
+        doReturn(carreiraDadosSrv).when(controlePersistencia)
+                .carregaCarreiraJogador(eq("usuario1"), eq(false), any(Session.class));
+
+        MsgSrv resultado = controlePersistencia.modoCarreira("usuario1", true);
+
+        assertNotNull(resultado);
+        verify(controlePersistencia, never()).gravarDados(any(), any());
+    }
+
+    @Test
+    void modoCarreira_desativandoModoCarreira_naoExigeDadosCompletos() throws Exception {
+        ControlePersistencia controlePersistencia = spy(new ControlePersistencia(null, null));
+        Session session = mock(Session.class);
+        doReturn(session).when(controlePersistencia).getSession();
+        CarreiraDadosSrv carreiraDadosSrv = new CarreiraDadosSrv();
+        carreiraDadosSrv.setNomeCarro("");
+        doReturn(carreiraDadosSrv).when(controlePersistencia)
+                .carregaCarreiraJogador(eq("usuario1"), eq(false), any(Session.class));
+        doNothing().when(controlePersistencia).gravarDados(any(), any());
+
+        controlePersistencia.modoCarreira("usuario1", false);
+
+        verify(controlePersistencia).gravarDados(eq(session), eq(carreiraDadosSrv));
+        assertEquals(false, carreiraDadosSrv.isModoCarreira());
+    }
+}

--- a/src/test/java/br/f1mane/servidor/rest/LetsRaceTest.java
+++ b/src/test/java/br/f1mane/servidor/rest/LetsRaceTest.java
@@ -1,0 +1,479 @@
+package br.f1mane.servidor.rest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.ws.rs.core.Response;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import br.f1mane.recursos.CarregadorRecursos;
+import br.f1mane.servidor.controles.ControleJogosServer;
+import br.f1mane.servidor.controles.ControlePaddockServidor;
+import br.f1mane.servidor.entidades.TOs.CampeonatoTO;
+import br.f1mane.servidor.entidades.TOs.ErroServ;
+import br.f1mane.servidor.entidades.TOs.MsgSrv;
+import br.f1mane.servidor.entidades.TOs.SessaoCliente;
+import br.f1mane.servidor.entidades.TOs.SrvPaddockPack;
+import br.f1mane.servidor.entidades.persistencia.CarreiraDadosSrv;
+import br.f1mane.recursos.idiomas.Lang;
+
+/**
+ * Testes da camada REST LetsRace: autenticação/autorização, mapeamento de
+ * MsgSrv/ErroServ para status HTTP e delegação correta de parâmetros para
+ * os controllers. ControlePaddockServidor e ControleJogosServer são
+ * mockados via Mockito; nenhum teste aqui sobe banco, thread ou Tomcat.
+ */
+class LetsRaceTest {
+
+    private ControlePaddockServidor controlePaddock;
+    private ControleJogosServer controleJogosServer;
+    private LetsRace letsRace;
+
+    private static final String TOKEN = "token-123";
+    private static final String IDIOMA = "pt";
+
+    @BeforeEach
+    void setUp() {
+        controlePaddock = mock(ControlePaddockServidor.class);
+        controleJogosServer = mock(ControleJogosServer.class);
+        when(controlePaddock.getControleJogosServer()).thenReturn(controleJogosServer);
+        CarregadorRecursos carregadorRecursos = mock(CarregadorRecursos.class);
+        letsRace = new LetsRace(carregadorRecursos, controlePaddock);
+    }
+
+    private SessaoCliente sessaoValida(boolean guest) {
+        SessaoCliente sessaoCliente = new SessaoCliente();
+        sessaoCliente.setGuest(guest);
+        sessaoCliente.setIdUsuario("usuario1");
+        return sessaoCliente;
+    }
+
+    // ---- verificaServico: endpoint sem nenhuma dependência ----
+
+    @Test
+    void verificaServico_naoChamaControlePaddock() {
+        Response response = letsRace.verificaServico();
+
+        assertEquals(200, response.getStatus());
+        assertEquals("ok", response.getEntity());
+    }
+
+    // ---- 401 quando a sessão é inválida ----
+
+    @Test
+    void jogar_tokenInvalido_retorna401ENaoDelegaParaController() {
+        when(controlePaddock.obterSessaoPorToken(TOKEN)).thenReturn(null);
+
+        Response response = letsRace.jogar(TOKEN, IDIOMA, "2024", "1", "interlagos",
+                "10", "MACIO", "50", "NORMAL", "false");
+
+        assertEquals(401, response.getStatus());
+        verify(controlePaddock, never()).jogar(any(), any(), any(), any(), any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void equipe_tokenInvalido_retorna401() {
+        when(controlePaddock.obterSessaoPorToken(TOKEN)).thenReturn(null);
+
+        Response response = letsRace.equipe(TOKEN, IDIOMA);
+
+        assertEquals(401, response.getStatus());
+        verify(controleJogosServer, never()).equipe(any());
+    }
+
+    @Test
+    void dadosParciais_tokenInvalido_retorna401() {
+        when(controlePaddock.obterSessaoPorToken(TOKEN)).thenReturn(null);
+
+        Response response = letsRace.dadosParciais(TOKEN, IDIOMA, "jogo1", "piloto1");
+
+        assertEquals(401, response.getStatus());
+    }
+
+    @Test
+    void potenciaMotor_tokenInvalido_retorna401() {
+        when(controlePaddock.obterSessaoPorToken(TOKEN)).thenReturn(null);
+
+        Response response = letsRace.potenciaMotor(TOKEN, "GIRO_MAX", "piloto1");
+
+        assertEquals(401, response.getStatus());
+        verify(controleJogosServer, never()).mudarGiroMotor(any(), any(), any());
+    }
+
+    // ---- 403 para sessão de visitante em endpoint restrito ----
+
+    @Test
+    void campeonato_sessaoVisitante_retorna403() {
+        when(controlePaddock.obterSessaoPorToken(TOKEN)).thenReturn(sessaoValida(true));
+
+        Response response = letsRace.campeonato(TOKEN, IDIOMA);
+
+        assertEquals(403, response.getStatus());
+        verify(controlePaddock, never()).obterCampeonatoEmAberto(any());
+    }
+
+    @Test
+    void campeonato_sessaoNaoVisitante_retorna200ComCampeonato() {
+        SessaoCliente sessaoCliente = sessaoValida(false);
+        when(controlePaddock.obterSessaoPorToken(TOKEN)).thenReturn(sessaoCliente);
+        CampeonatoTO campeonatoTO = new CampeonatoTO();
+        when(controlePaddock.obterCampeonatoEmAberto("usuario1")).thenReturn(campeonatoTO);
+
+        Response response = letsRace.campeonato(TOKEN, IDIOMA);
+
+        assertEquals(200, response.getStatus());
+        assertEquals(campeonatoTO, response.getEntity());
+    }
+
+    @Test
+    void campeonato_semCampeonatoEmAberto_retorna204() {
+        when(controlePaddock.obterSessaoPorToken(TOKEN)).thenReturn(sessaoValida(false));
+        when(controlePaddock.obterCampeonatoEmAberto("usuario1")).thenReturn(null);
+
+        Response response = letsRace.campeonato(TOKEN, IDIOMA);
+
+        assertEquals(204, response.getStatus());
+    }
+
+    // ---- criarSessaoNome: regressão do bug de serialização de ErroServ ----
+
+    @Test
+    void criarSessaoNome_sucesso_retorna200ComPayload() {
+        SrvPaddockPack pack = new SrvPaddockPack();
+        when(controlePaddock.criarSessaoNome("Piloto")).thenReturn(pack);
+
+        Response response = letsRace.criarSessaoNome("Piloto");
+
+        assertEquals(200, response.getStatus());
+        assertEquals(pack, response.getEntity());
+    }
+
+    @Test
+    void criarSessaoNome_erroNoController_retorna500ComErroServ() {
+        ErroServ erroServ = new ErroServ(new RuntimeException("falha de banco"));
+        when(controlePaddock.criarSessaoNome("Piloto")).thenReturn(erroServ);
+
+        Response response = letsRace.criarSessaoNome("Piloto");
+
+        assertEquals(500, response.getStatus());
+        assertEquals(erroServ, response.getEntity());
+    }
+
+    @Test
+    void criarSessaoGoogle_erroNoController_retorna500() {
+        ErroServ erroServ = new ErroServ(new RuntimeException("falha"));
+        when(controlePaddock.criarSessaoGoogle("g1", "Nome", "url", "a@b.com"))
+                .thenReturn(erroServ);
+
+        Response response = letsRace.criarSessaoGoogle("g1", "Nome", "url", "a@b.com");
+
+        assertEquals(500, response.getStatus());
+    }
+
+    // ---- processsaMensagem: MsgSrv -> 400, ErroServ -> 500, sucesso -> 200 ----
+
+    @Test
+    void jogar_controllerRetornaMsgSrv_retorna400ComMensagemTraduzida() {
+        when(controlePaddock.obterSessaoPorToken(TOKEN)).thenReturn(sessaoValida(false));
+        when(controlePaddock.jogar(eq("2024"), eq("interlagos"), eq("1"), eq("10"),
+                eq("MACIO"), eq("50"), eq("NORMAL"), any(SessaoCliente.class), eq("false")))
+                .thenReturn(new MsgSrv("Carro indisponivel"));
+
+        Response response = letsRace.jogar(TOKEN, IDIOMA, "2024", "1", "interlagos",
+                "10", "MACIO", "50", "NORMAL", "false");
+
+        assertEquals(400, response.getStatus());
+        assertEquals("Carro indisponivel", ((MsgSrv) response.getEntity()).getMessageString());
+    }
+
+    @Test
+    void jogar_controllerRetornaErroServ_retorna500ComMensagemFormatada() {
+        when(controlePaddock.obterSessaoPorToken(TOKEN)).thenReturn(sessaoValida(false));
+        ErroServ erroServ = new ErroServ(new RuntimeException("boom"));
+        when(controlePaddock.jogar(any(), any(), any(), any(), any(), any(), any(), any(), any()))
+                .thenReturn(erroServ);
+
+        Response response = letsRace.jogar(TOKEN, IDIOMA, "2024", "1", "interlagos",
+                "10", "MACIO", "50", "NORMAL", "false");
+
+        assertEquals(500, response.getStatus());
+        assertEquals(erroServ.obterErroFormatado(),
+                ((MsgSrv) response.getEntity()).getMessageString());
+    }
+
+    @Test
+    void jogar_sucesso_retorna200ComPayloadDoController() {
+        SessaoCliente sessaoCliente = sessaoValida(false);
+        when(controlePaddock.obterSessaoPorToken(TOKEN)).thenReturn(sessaoCliente);
+        Object dadosJogo = new Object();
+        when(controlePaddock.jogar(eq("2024"), eq("interlagos"), eq("1"), eq("10"),
+                eq("MACIO"), eq("50"), eq("NORMAL"), eq(sessaoCliente), eq("false")))
+                .thenReturn(dadosJogo);
+
+        Response response = letsRace.jogar(TOKEN, IDIOMA, "2024", "1", "interlagos",
+                "10", "MACIO", "50", "NORMAL", "false");
+
+        assertEquals(200, response.getStatus());
+        assertEquals(dadosJogo, response.getEntity());
+    }
+
+    @Test
+    void equipe_controllerRetornaNull_retorna204() {
+        when(controlePaddock.obterSessaoPorToken(TOKEN)).thenReturn(sessaoValida(false));
+        when(controleJogosServer.equipe(any())).thenReturn(null);
+
+        Response response = letsRace.equipe(TOKEN, IDIOMA);
+
+        assertEquals(204, response.getStatus());
+    }
+
+    @Test
+    void equipe_controllerRetornaErroServ_retorna500() {
+        when(controlePaddock.obterSessaoPorToken(TOKEN)).thenReturn(sessaoValida(false));
+        ErroServ erroServ = new ErroServ(new RuntimeException("falha"));
+        when(controleJogosServer.equipe(any())).thenReturn(erroServ);
+
+        Response response = letsRace.equipe(TOKEN, IDIOMA);
+
+        assertEquals(500, response.getStatus());
+    }
+
+    @Test
+    void equipe_sucesso_retorna200() {
+        when(controlePaddock.obterSessaoPorToken(TOKEN)).thenReturn(sessaoValida(false));
+        Object equipe = new Object();
+        when(controleJogosServer.equipe(any())).thenReturn(equipe);
+
+        Response response = letsRace.equipe(TOKEN, IDIOMA);
+
+        assertEquals(200, response.getStatus());
+        assertEquals(equipe, response.getEntity());
+    }
+
+    // ---- gravarEquipe: caminho de sucesso usa comparação literal com Lang.msg("250") ----
+
+    @Test
+    void gravarEquipe_tokenInvalido_retorna401() {
+        when(controlePaddock.obterSessaoPorToken(TOKEN)).thenReturn(null);
+
+        Response response = letsRace.gravarEquipe(TOKEN, IDIOMA, new CarreiraDadosSrv());
+
+        assertEquals(401, response.getStatus());
+    }
+
+    @Test
+    void gravarEquipe_sucesso_retorna200() {
+        when(controlePaddock.obterSessaoPorToken(TOKEN)).thenReturn(sessaoValida(false));
+        MsgSrv sucesso = new MsgSrv(Lang.msg("250"));
+        when(controleJogosServer.gravarEquipe(any(), eq(IDIOMA), any())).thenReturn(sucesso);
+
+        Response response = letsRace.gravarEquipe(TOKEN, IDIOMA, new CarreiraDadosSrv());
+
+        assertEquals(200, response.getStatus());
+    }
+
+    @Test
+    void gravarEquipe_falhaDeValidacao_retorna400() {
+        when(controlePaddock.obterSessaoPorToken(TOKEN)).thenReturn(sessaoValida(false));
+        when(controleJogosServer.gravarEquipe(any(), eq(IDIOMA), any()))
+                .thenReturn(new MsgSrv("Nome de equipe invalido"));
+
+        Response response = letsRace.gravarEquipe(TOKEN, IDIOMA, new CarreiraDadosSrv());
+
+        assertEquals(400, response.getStatus());
+    }
+
+    // ---- delegação simples de controles de piloto ----
+
+    @Test
+    void potenciaMotor_delegaParaControleJogosServerComParametrosCorretos() {
+        SessaoCliente sessaoCliente = sessaoValida(false);
+        when(controlePaddock.obterSessaoPorToken(TOKEN)).thenReturn(sessaoCliente);
+        when(controleJogosServer.mudarGiroMotor(sessaoCliente, "piloto1", "GIRO_MAX"))
+                .thenReturn(Boolean.TRUE);
+
+        Response response = letsRace.potenciaMotor(TOKEN, "GIRO_MAX", "piloto1");
+
+        assertEquals(200, response.getStatus());
+        assertEquals(Boolean.TRUE, response.getEntity());
+        verify(controleJogosServer).mudarGiroMotor(sessaoCliente, "piloto1", "GIRO_MAX");
+    }
+
+    @Test
+    void agressividadePiloto_delegaComParametrosCorretos() {
+        SessaoCliente sessaoCliente = sessaoValida(false);
+        when(controlePaddock.obterSessaoPorToken(TOKEN)).thenReturn(sessaoCliente);
+
+        letsRace.agressividadePiloto(TOKEN, "AGRESSIVO", "piloto1");
+
+        verify(controleJogosServer).mudarAgressividadePiloto(sessaoCliente, "piloto1", "AGRESSIVO");
+    }
+
+    @Test
+    void tracadoPiloto_delegaComParametrosCorretos() {
+        SessaoCliente sessaoCliente = sessaoValida(false);
+        when(controlePaddock.obterSessaoPorToken(TOKEN)).thenReturn(sessaoCliente);
+
+        letsRace.tracadoPiloto(TOKEN, "INTERNO", "piloto1");
+
+        verify(controleJogosServer).mudarTracadoPiloto(sessaoCliente, "piloto1", "INTERNO");
+    }
+
+    @Test
+    void drsPiloto_delegaComParametrosCorretos() {
+        SessaoCliente sessaoCliente = sessaoValida(false);
+        when(controlePaddock.obterSessaoPorToken(TOKEN)).thenReturn(sessaoCliente);
+
+        letsRace.drsPiloto(TOKEN, "piloto1");
+
+        verify(controleJogosServer).mudarDrs(sessaoCliente, "piloto1");
+    }
+
+    @Test
+    void ersPiloto_delegaComParametrosCorretos() {
+        SessaoCliente sessaoCliente = sessaoValida(false);
+        when(controlePaddock.obterSessaoPorToken(TOKEN)).thenReturn(sessaoCliente);
+
+        letsRace.ersPiloto(TOKEN, "piloto1");
+
+        verify(controleJogosServer).mudarErs(sessaoCliente, "piloto1");
+    }
+
+    @Test
+    void boxPiloto_delegaTodosOsParametrosDePitStop() {
+        SessaoCliente sessaoCliente = sessaoValida(false);
+        when(controlePaddock.obterSessaoPorToken(TOKEN)).thenReturn(sessaoCliente);
+
+        letsRace.boxPiloto(TOKEN, "piloto1", true, "MACIO", 50, "BAIXA");
+
+        verify(controleJogosServer).boxPiloto(sessaoCliente, "piloto1", true, "MACIO", 50, "BAIXA");
+    }
+
+    // ---- endpoints de leitura simples ----
+
+    @Test
+    void obterJogos_retorna200ComListaDoController() {
+        when(controlePaddock.obterJogos()).thenReturn(java.util.List.of("jogo1", "jogo2"));
+
+        Response response = letsRace.obterJogos();
+
+        assertEquals(200, response.getStatus());
+        assertEquals(java.util.List.of("jogo1", "jogo2"), response.getEntity());
+    }
+
+    @Test
+    void classificacaoGeral_retorna200ComResultadoDoController() {
+        Object classificacao = new Object();
+        when(controlePaddock.obterClassificacaoGeral()).thenReturn(classificacao);
+
+        Response response = letsRace.classificacaoGeral();
+
+        assertEquals(200, response.getStatus());
+        assertEquals(classificacao, response.getEntity());
+    }
+
+    @Test
+    void campeonatoPorId_naoExiste_retorna204() {
+        when(controlePaddock.obterCampeonatoId("99")).thenReturn(null);
+
+        Response response = letsRace.campeonatoPorId("99", TOKEN, IDIOMA);
+
+        assertEquals(204, response.getStatus());
+        assertNull(response.getEntity());
+    }
+
+    @Test
+    void classificacaoEquipes_retorna200ComResultadoDoController() {
+        Object classificacao = new Object();
+        when(controlePaddock.obterClassificacaoEquipes()).thenReturn(classificacao);
+
+        Response response = letsRace.classificacaoEquipes();
+
+        assertEquals(200, response.getStatus());
+        assertEquals(classificacao, response.getEntity());
+    }
+
+    @Test
+    void classificacaoCampeonato_retorna200ComResultadoDoController() {
+        Object classificacao = new Object();
+        when(controlePaddock.obterClassificacaoCampeonato()).thenReturn(classificacao);
+
+        Response response = letsRace.classificacaoCampeonato();
+
+        assertEquals(200, response.getStatus());
+        assertEquals(classificacao, response.getEntity());
+    }
+
+    @Test
+    void atualizarDadosVisao_retorna200ComResultadoDoController() {
+        Object dadosVisao = new Object();
+        when(controlePaddock.atualizarDadosVisao()).thenReturn(dadosVisao);
+
+        Response response = letsRace.atualizarDadosVisao();
+
+        assertEquals(200, response.getStatus());
+        assertEquals(dadosVisao, response.getEntity());
+    }
+
+    @Test
+    void dadosToken_tokenValido_retorna200ComPack() {
+        SrvPaddockPack pack = new SrvPaddockPack();
+        pack.setSessaoCliente(sessaoValida(false));
+        when(controlePaddock.obterDadosToken(TOKEN)).thenReturn(pack);
+
+        Response response = letsRace.dadosToken(TOKEN);
+
+        assertEquals(200, response.getStatus());
+        assertEquals(pack, response.getEntity());
+    }
+
+    @Test
+    void dadosToken_semSessao_retorna404() {
+        when(controlePaddock.obterDadosToken(TOKEN)).thenReturn(null);
+
+        Response response = letsRace.dadosToken(TOKEN);
+
+        assertEquals(404, response.getStatus());
+    }
+
+    @Test
+    void sairJogo_tokenInvalido_retorna401() {
+        when(controlePaddock.obterSessaoPorToken(TOKEN)).thenReturn(null);
+
+        Response response = letsRace.sairJogo(TOKEN, "jogo1");
+
+        assertEquals(401, response.getStatus());
+        verify(controlePaddock, never()).sairJogoToken(any(), any(), any());
+    }
+
+    @Test
+    void sairJogo_tokenValido_delegaParaController() {
+        SessaoCliente sessaoCliente = sessaoValida(false);
+        when(controlePaddock.obterSessaoPorToken(TOKEN)).thenReturn(sessaoCliente);
+
+        Response response = letsRace.sairJogo(TOKEN, "jogo1");
+
+        assertEquals(200, response.getStatus());
+        verify(controlePaddock).sairJogoToken("jogo1", TOKEN, sessaoCliente);
+    }
+
+    @Test
+    void circuitos_retorna200ComListaDoCarregadorRecursos() throws Exception {
+        CarregadorRecursos carregadorRecursosMock = mock(CarregadorRecursos.class);
+        LetsRace letsRaceComCarregador = new LetsRace(carregadorRecursosMock, controlePaddock);
+        when(carregadorRecursosMock.carregarCircuitosDefaults())
+                .thenReturn(java.util.List.of());
+
+        Response response = letsRaceComCarregador.circuitos();
+
+        assertEquals(200, response.getStatus());
+    }
+}

--- a/src/test/java/br/nnpe/UtilTest.java
+++ b/src/test/java/br/nnpe/UtilTest.java
@@ -1,0 +1,88 @@
+package br.nnpe;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+/**
+ * Cobre Util.processaValorPontosCarreira, responsável pelo custo/refund de
+ * pontos por faixa de nível no modo carreira. Regressão do bug de pontos
+ * infinitos no nível 999 corrigido no commit f47e7a74.
+ */
+class UtilTest {
+
+    @Test
+    void upgrade998Para999_debita50Pontos() {
+        Numero numero = new Numero(1000);
+
+        Util.processaValorPontosCarreira(998, 999, numero);
+
+        assertEquals(950.0, numero.getNumero());
+    }
+
+    @Test
+    void downgrade999Para998_credita50Pontos() {
+        Numero numero = new Numero(1000);
+
+        Util.processaValorPontosCarreira(999, 998, numero);
+
+        assertEquals(1050.0, numero.getNumero());
+    }
+
+    @Test
+    void cicloDowngradeUpgradeNoNivel999_naoAlteraSaldo() {
+        Numero numero = new Numero(1000);
+
+        Util.processaValorPontosCarreira(999, 998, numero);
+        Util.processaValorPontosCarreira(998, 999, numero);
+
+        assertEquals(1000.0, numero.getNumero());
+    }
+
+    @ParameterizedTest(name = "{0}->{1} custa {2} pontos")
+    @CsvSource({
+            // valorAtual, proximoValor, custoEsperado
+            "100, 101, 1",
+            "599, 600, 2",
+            "600, 601, 2",
+            "699, 700, 10",
+            "700, 701, 10",
+            "799, 800, 20",
+            "800, 801, 20",
+            "899, 900, 50",
+            "900, 901, 50",
+            "998, 999, 50"
+    })
+    void upgrade_seguePorFaixaDeCusto(int valorAtual, int proximoValor, double custoEsperado) {
+        Numero numero = new Numero(2000);
+
+        Util.processaValorPontosCarreira(valorAtual, proximoValor, numero);
+
+        assertEquals(2000.0 - custoEsperado, numero.getNumero());
+    }
+
+    @ParameterizedTest(name = "{0}->{1} devolve {2} pontos")
+    @CsvSource({
+            "101, 100, 1",
+            // downgrade saindo exatamente de uma centena cheia (600/700/800/900)
+            // custa o mesmo da faixa superior, simetricamente ao upgrade que entrou nela
+            "600, 599, 2",
+            "601, 600, 2",
+            "700, 699, 10",
+            "701, 700, 10",
+            "800, 799, 20",
+            "801, 800, 20",
+            "900, 899, 50",
+            "901, 900, 50",
+            "999, 998, 50"
+    })
+    void downgrade_seguePorFaixaDeRefund(int valorAtual, int proximoValor, double refundEsperado) {
+        Numero numero = new Numero(2000);
+
+        Util.processaValorPontosCarreira(valorAtual, proximoValor, numero);
+
+        assertEquals(2000.0 + refundEsperado, numero.getNumero());
+    }
+}


### PR DESCRIPTION
…tes) e cobertura JaCoCo

- Infra: JUnit 5 + Mockito (escopo test), maven-surefire-plugin, mvn test documentado no CLAUDE.md
- LetsRace: novo construtor pacote-privado para injeção de teste (ControlePaddockServidor/CarregadorRecursos), construtor público inalterado
- Testes de LetsRace (37): autenticação/autorização, mapeamento MsgSrv->400/ErroServ->500, delegação de endpoints
- Testes de br.f1mane.servidor.controles (74): ControleClassificacao, ControleCampeonatoServidor, ControlePaddockServidor, ControleJogosServer, ControlePersistencia
- Testes de Util.processaValorPontosCarreira (23): tabela de custo/refund por faixa, regressão do bug de pontos infinitos no nível 999
- Injeção de dependência de CarregadorRecursos em ControleClassificacao/ControleCampeonatoServidor/ControlePaddockServidor, desbloqueando teste das validações de livery/capacete e do caminho de sucesso de criarCampeonato
- Remove Global.DATABASE (código morto: constante de compilação travada em true, nunca configurável em runtime) e os 9 branches mortos que dependiam dela
- Adiciona JaCoCo para relatório de cobertura (target/site/jacoco/index.html via mvn test)
- Specs do openspec arquivadas e sincronizadas: unit-testing-infra, letsrace-endpoint-tests, controles-business-logic-tests