### PR TITLE
feat: reformula editor de circuitos e adiciona propriedade ativo

### DIFF
--- a/openspec/changes/archive/2026-07-02-reformular-editor-circuitos/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-02-reformular-editor-circuitos/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-02

--- a/openspec/changes/archive/2026-07-02-reformular-editor-circuitos/design.md
+++ b/openspec/changes/archive/2026-07-02-reformular-editor-circuitos/design.md
@@ -1,0 +1,64 @@
+## Context
+
+O editor de circuitos (`br.f1mane.editor.EditorCircuitos` + `MainPanelEditor`, ~2126 linhas) hoje:
+- Seleciona circuito existente via `JFileChooser` bruto (`MainPanelEditor.editar()`), sem relação com `circuitos.properties`.
+- Layout em `BorderLayout`: nós (`pistaJList`/`boxJList`) a WEST via `gerarListsNosPistaBox()`; dois `FormularioListaObjetos` empilhados a EAST (`objetos` e `objetosCenario`, adicionados na mudança recente de objetos de cenário); botões de ação de nó e de objeto soltos em `buttonsPanel`/`gerarBotoesTracado()` no NORTH.
+- `JMenuBar` com menus "Editor" (Criar/Editar/Salvar) e "Informações" (logs/debug/sobre).
+- `Circuito` persiste via `java.beans.XMLEncoder`/`XMLDecoder` (introspecção JavaBeans — precisa de par `isX()`/`setX()` para cada propriedade booleana; propriedades no valor padrão do construtor não são serializadas).
+- A cadeia runtime de exposição de circuitos ao jogador é: `circuitos.properties` → `ControleRecursos.carregarCircuitos()` (cache estático `Map<String,String>` nome→arquivo) → consumida por `GerenciadorVisual.gerarSeletorCircuito()` (combo solo), `PainelEntradaCliente` (combo multiplayer applet) e `CarregadorRecursos.carregarCircuitosDefaults()` → `LetsRace.circuitos()` (REST, já decodifica cada `Circuito` via XML para anexar `probalidadeChuva`).
+
+O padrão de navegação por temporada a ser replicado vive em `EditorCoresCarros`: dois `JButton` (Anterior/Próximo) + `JLabel`, populados por `popularTemporadas()` (lê `properties/temporadas.properties`, com fallback de varredura de diretório) e `navegarTemporada(delta)`/`atualizarNavegacaoTemporada()` que habilitam/desabilitam os botões nas pontas da lista e disparam o carregamento.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Substituir o `JFileChooser` de seleção de circuito existente por navegação Anterior/Próximo sobre a lista de `circuitos.properties`, replicando o padrão de `EditorCoresCarros`.
+- Consolidar as listas de nós e de objetos em um único `JSplitPane` lateral, com as ações de cada domínio (nó vs. objeto) agrupadas na seção correspondente.
+- Remover o `JMenuBar` do editor, substituindo por botões "Salvar Pista Atual" e "Criar Nova".
+- Adicionar `ativo` (boolean, default `false`) a `Circuito`, e filtrar circuitos inativos dos seletores em jogo (solo, multiplayer applet, REST), sem impedir que o editor continue exibindo/editando-os.
+
+**Non-Goals:**
+- Não reescrever o mecanismo de persistência (continua `XMLEncoder`/`XMLDecoder`, sem migração para JSON/DB).
+- Não alterar `circuitos.properties` para incluir uma terceira coluna com o status ativo — o status vive exclusivamente no XML do `Circuito` (ver Decisão 3).
+- Não mexer no fluxo de teste de pista (`TestePista`), no menu de "Informações" enquanto funcionalidade de debug (essas ações somem da UI do editor, mas os atalhos/flags `Global.DEBUG` etc. continuam existindo no código, só não ficam mais acessíveis por esse menu específico).
+- Não alterar o formato do `FormularioListaObjetos` em si (Cima/Baixo/Primeiro/Ultimo/Editar/Remover) — ele é reaproveitado dentro da nova seção de objetos do split pane sem mudança de contrato.
+
+## Decisions
+
+### 1. Navegação Anterior/Próximo lendo `circuitos.properties`, com fallback de varredura de diretório
+Réplica direta do padrão já validado em `EditorCoresCarros.popularTemporadas()`: fonte primária é `properties/circuitos.properties` (já é a fonte de verdade em runtime via `ControleRecursos.carregarCircuitos()`), com fallback de varredura de `src/main/resources/circuitos/*.xml` caso a properties não possa ser lida. A troca de circuito chama `CarregadorRecursos.carregarCircuito(nomeArquivoXml)` (mesmo método já usado por `editar()` hoje) em vez de abrir um `JFileChooser`.
+**Alternativa considerada**: manter `JFileChooser` e apenas adicionar botões Anterior/Próximo por cima — rejeitada porque o pedido explícito é usar exatamente o padrão do editor de carros, e manter o file chooser paralelo criaria duas formas divergentes de abrir o mesmo arquivo.
+
+### 2. Layout: um único `JSplitPane` lateral com duas seções (nós / objetos)
+Substitui o atual WEST (nós) + EAST (dois painéis de objeto empilhados) por um só `JSplitPane` (orientação vertical, `JSplitPane.VERTICAL_SPLIT`) posicionado em um único lado (EAST, mantendo o canvas maior à esquerda). A seção superior contém as duas `JList` de nós (pista/box) mais os botões de ação de nó (inserir via seleção de rádio + clique já existente, "Apagar Ultimo NO", "Apaga Nó na lista Selecionada"). A seção inferior contém os dois `FormularioListaObjetos` (objetos/objetosCenario) mais o botão "Criar Objeto".
+**Alternativa considerada**: `JSplitPane` horizontal com nós à esquerda e objetos à direita (dois lados) — rejeitada porque o pedido é consolidar em "apenas uma lateral".
+**Alternativa considerada**: um único `JTabbedPane` em vez de `JSplitPane` — rejeitada porque o pedido específico menciona "split panel", e um split mantém nós e objetos visíveis simultaneamente (importante já que arrastar/clicar objetos no canvas precisa de visibilidade constante da lista).
+
+### 3. `ativo` como propriedade do `Circuito` (XML), não coluna em `circuitos.properties`
+`ativo` fica exclusivamente no XML do circuito (`Circuito.isAtivo()/setAtivo()`, JavaBeans), não em `circuitos.properties`. Motivo: `circuitos.properties` é uma lista estática mantida a mão; colocar o status lá duplicaria a fonte de verdade com o editor (que só escreve o XML). O custo é que os pontos de filtragem em runtime (`CarregadorRecursos.carregarCircuitosDefaults()`, `GerenciadorVisual.gerarSeletorCircuito()`, `PainelEntradaCliente`) precisam decodificar o XML de cada circuito para checar `isAtivo()`.
+**Mitigação de custo**: `carregarCircuitosDefaults()` já decodifica cada `Circuito` (para ler `probalidadeChuva`), então o filtro ali é gratuito. Para os dois combo boxes Swing (`GerenciadorVisual`, `PainelEntradaCliente`), que hoje só usam o `Map<String,String>` de `ControleRecursos.carregarCircuitos()` sem decodificar XML, a decodificação adicional (uma vez, ao montar o combo, dezenas de arquivos) é aceitável — não é um caminho quente de execução.
+**Alternativa considerada**: adicionar 3ª coluna `ativo` em `circuitos.properties` e evitar decodificar XML nos combos — rejeitada porque o pedido do usuário é uma propriedade do circuito, e manter duas fontes de verdade (properties + XML) para o mesmo dado convida a divergência (alguém edita o XML e esquece de atualizar o properties).
+
+### 4. Default `false` exige migração explícita dos 37 circuitos existentes
+Como o construtor padrão de `Circuito` passa a ter `ativo=false`, e `XMLEncoder` só grava propriedades que divergem do padrão do construtor, todo circuito já existente em `src/main/resources/circuitos/*.xml` precisa ganhar `<void property="ativo"><boolean>true</boolean></void>` explicitamente — senão, no primeiro carregamento pós-mudança, todos os circuitos hoje jogáveis desaparecem dos seletores. Isso é tratado como passo de migração dedicado em `tasks.md` (script ou edição em lote dos XMLs), executado antes/junto da mudança de filtragem entrar em vigor.
+
+## Risks / Trade-offs
+
+- [Risco] Migração incompleta dos 37 XMLs deixa circuitos jogáveis hoje invisíveis após a mudança → Mitigação: task dedicada de migração em lote com verificação (contar quantos `*_mro.xml` existem vs. quantos têm `ativo=true` após a edição, antes de considerar a mudança concluída).
+- [Risco] Decodificar XML de todo circuito ao montar `GerenciadorVisual.gerarSeletorCircuito()`/`PainelEntradaCliente` adiciona I/O síncrono na montagem da tela → Mitigação: é uma operação de UI de configuração inicial (não por frame), sobre dezenas de arquivos pequenos; aceitável sem cache adicional nesta mudança.
+- [Trade-off] Remover o menu "Informações" (logs/debug/sobre) do editor reduz descoberta dessas funções para quem não conhece atalhos/flags — aceito porque o pedido explícito do usuário é reduzir a UI a apenas salvar/criar.
+- [Risco] `JSplitPane` único lateral reduz a área visível simultânea de nós+objetos comparado ao layout atual de dois lados — Mitigação: divisor arrastável (`JSplitPane` permite redimensionar em tempo de uso) e proporção inicial razoável (ex.: 50/50) definida no `tasks.md`.
+
+## Migration Plan
+
+1. Adicionar `ativo`/`isAtivo`/`setAtivo` a `Circuito` (default `false`) sem ainda ativar filtragem em runtime.
+2. Editar em lote os 37 XMLs existentes em `src/main/resources/circuitos/` para `ativo=true` (script ou edição direta), validando que a contagem bate.
+3. Ativar a filtragem por `isAtivo()` em `CarregadorRecursos.carregarCircuitosDefaults()`, `GerenciadorVisual.gerarSeletorCircuito()`, `PainelEntradaCliente` e `LetsRace.circuitos()`.
+4. Reformular a UI do editor (split pane, navegação Anterior/Próximo, remoção do menu, botões Salvar/Criar) — não depende estritamente da ordem acima, mas faz sentido só entregar depois que `ativo` já existe no modelo, para o editor já poder expor um controle de "ativo" ao usuário do editor (checkbox) se necessário.
+
+Rollback: reverter a filtragem (passos 3) é suficiente para restaurar o comportamento atual sem depender de reverter a UI do editor; os dois são independentes o bastante para reverts parciais.
+
+## Open Questions
+
+- O editor precisa expor um checkbox visível para alternar `ativo` diretamente na tela principal, ou isso fica apenas acessível via edição futura (formulário)? Assumido: sim, um checkbox simples perto dos botões Salvar/Criar, já que sem isso não há como o usuário do editor tornar um circuito jogável pela UI.
+- Qual o nome exibido nos botões de topo — "Salvar Pista Atual"/"Criar Nova" (conforme pedido) — precisa de confirmação visual/rótulo final, mas segue o texto literal do pedido para esta proposta.

--- a/openspec/changes/archive/2026-07-02-reformular-editor-circuitos/proposal.md
+++ b/openspec/changes/archive/2026-07-02-reformular-editor-circuitos/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+O editor de circuitos (`EditorCircuitos`/`MainPanelEditor`) hoje espalha as ações de edição de nós e de objetos de pista em painéis distintos (nós a oeste, dois painéis de objetos empilhados a leste, botões soltos ao norte), seleciona circuitos existentes por `JFileChooser` bruto sem nenhuma relação com `circuitos.properties`, e expõe todas as ações por um `JMenuBar` com itens de debug/logs misturados aos de edição. Isso torna o fluxo de criar/editar uma pista mais lento e inconsistente com o padrão de navegação por temporada já usado em `EditorCoresCarros`. Além disso, não existe hoje nenhuma forma de manter um circuito em desenvolvimento no repositório sem que ele apareça imediatamente como jogável.
+
+## What Changes
+
+- O editor de circuitos passa a carregar/selecionar circuitos existentes com navegação Anterior/Próximo sobre a lista vinda de `circuitos.properties` (mesmo padrão de `EditorCoresCarros.popularTemporadas()`/`navegarTemporada()`), em vez do `JFileChooser` atual usado por `MainPanelEditor.editar()`.
+- As listas de nós (`pistaJList`/`boxJList`) e as listas de objetos (`objetos`/`objetosCenario`, hoje em dois `FormularioListaObjetos` separados a leste) passam a ficar em um único `JSplitPane` lateral, com uma seção para nós e outra para objetos de pista.
+- As ações relativas a nós (inserir, apagar, apagar último) são agrupadas na seção de nós do split pane; as ações relativas a objetos de pista (criar, remover, reordenar, editar) são agrupadas na seção de objetos do split pane — em vez de ficarem em botões soltos no painel norte (`buttonsPanel`) e nos painéis de lista.
+- `Circuito` ganha uma propriedade booleana `ativo`, com valor padrão `false`. **BREAKING**: circuitos sem essa propriedade explicitamente marcada como `true` deixam de aparecer nos seletores de circuito do jogo (solo e multiplayer), mesmo continuando editáveis no editor.
+- O `JMenuBar` de `EditorCircuitos` é removido. As únicas ações de topo passam a ser botões: "Salvar Pista Atual" e "Criar Nova". Itens de debug/logs/sobre-o-autor saem do menu do editor (deixam de existir nesta tela).
+
+## Capabilities
+
+### New Capabilities
+- `circuito-ativo`: adiciona a propriedade `ativo` (boolean, default `false`) a `Circuito`, persistida via `XMLEncoder`/`XMLDecoder` como as demais propriedades booleanas (`noite`, `usaBkg`), e filtra circuitos inativos dos seletores em jogo (solo `GerenciadorVisual`, cliente multiplayer `PainelEntradaCliente`, endpoint REST `LetsRace.circuitos()`), mantendo-os visíveis e editáveis no editor de circuitos.
+
+### Modified Capabilities
+- `dev-editor-tools`: a seleção de circuito existente para edição deixa de usar `JFileChooser` e passa a usar navegação Anterior/Próximo sobre `circuitos.properties`, mesmo padrão de `EditorCoresCarros`; o `JMenuBar` de `EditorCircuitos` é removido em favor de botões "Salvar Pista Atual"/"Criar Nova".
+- `objetos-cenario-circuito`: os painéis de lista de nós e de objetos de pista (hoje em `BorderLayout` WEST/EAST separados) passam a viver em um único `JSplitPane` lateral, com as ações de nó agrupadas na seção de nós e as ações de objeto agrupadas na seção de objetos.
+
+## Impact
+
+- `br.f1mane.editor.EditorCircuitos`: remoção do `JMenuBar` (`gerarMenusEditor`), adição dos botões "Salvar Pista Atual"/"Criar Nova".
+- `br.f1mane.editor.MainPanelEditor`: maior reformulação — substitui `gerarListsNosPistaBox()` (WEST) e `listasObjetosPanel` (EAST) por um único `JSplitPane`; reagrupa botões de `buttonsPanel`/`gerarBotoesTracado()` nas seções correspondentes; substitui o `JFileChooser` de `editar()` por navegação Anterior/Próximo lendo `circuitos.properties`; `novo()` e `salvarPista()` ajustados para o novo fluxo de botões.
+- `br.f1mane.editor.FormularioListaObjetos`: reaproveitado dentro da nova seção de objetos do split pane (sem mudança de contrato).
+- `br.f1mane.entidades.Circuito`: novo campo `ativo` (boolean, default `false`) com `isAtivo()`/`setAtivo(boolean)`.
+- `src/main/resources/properties/circuitos.properties`: passa a ser a fonte usada pela navegação Anterior/Próximo do editor (leitura), além do uso já existente em runtime.
+- `src/main/resources/circuitos/*.xml`: **migração necessária** — todos os 37 circuitos hoje jogáveis precisam ganhar `ativo=true` explicitamente, senão desaparecem do jogo com o novo default `false`.
+- `br.f1mane.controles.ControleRecursos` / `br.f1mane.recursos.CarregadorRecursos` (`carregarCircuitosDefaults`): precisam decodificar `isAtivo()` de cada `Circuito` para filtrar a lista exposta ao REST e aos seletores.
+- `br.f1mane.visao.GerenciadorVisual` (`gerarSeletorCircuito`) e cliente multiplayer `PainelEntradaCliente`: filtram circuitos inativos do combo box exibido ao jogador.
+- `br.f1mane.servidor.rest.LetsRace` (`GET /circuitos`): passa a retornar apenas circuitos ativos.

--- a/openspec/changes/archive/2026-07-02-reformular-editor-circuitos/specs/circuito-ativo/spec.md
+++ b/openspec/changes/archive/2026-07-02-reformular-editor-circuitos/specs/circuito-ativo/spec.md
@@ -1,0 +1,38 @@
+## ADDED Requirements
+
+### Requirement: Circuito tem propriedade ativo com valor padrão false
+`Circuito` SHALL expor uma propriedade booleana `ativo` (`isAtivo()`/`setAtivo(boolean)`), persistida via `XMLEncoder`/`XMLDecoder` do mesmo jeito que `noite`/`usaBkg`, com valor padrão `false` quando não definida explicitamente.
+
+#### Scenario: Circuito recém-criado nasce inativo
+- **WHEN** um novo `Circuito` é criado pelo editor (fluxo "Criar Nova") sem que o usuário marque explicitamente a propriedade ativo
+- **THEN** `circuito.isAtivo()` retorna `false`
+
+#### Scenario: XML sem a propriedade ativo carrega como inativo
+- **WHEN** um arquivo XML de circuito existente é decodificado por `XMLDecoder` e não contém `<void property="ativo">`
+- **THEN** o `Circuito` resultante tem `isAtivo()` retornando `false`, pelo comportamento padrão do construtor sem argumentos
+
+### Requirement: Circuitos inativos não aparecem nos seletores em jogo
+O sistema SHALL excluir circuitos com `isAtivo()` igual a `false` de todas as superfícies de seleção de circuito em jogo — combo solo (`GerenciadorVisual.gerarSeletorCircuito()`), combo do cliente multiplayer (`PainelEntradaCliente`) e endpoint REST `GET /circuitos` (`LetsRace.circuitos()`/`CarregadorRecursos.carregarCircuitosDefaults()`) — mantendo-os abríveis e editáveis no editor de circuitos.
+
+#### Scenario: Seletor solo exclui circuito inativo
+- **WHEN** `GerenciadorVisual.gerarSeletorCircuito()` monta o combo box de circuitos e um circuito tem `ativo=false`
+- **THEN** esse circuito não aparece como opção no combo box
+
+#### Scenario: Cliente multiplayer exclui circuito inativo
+- **WHEN** `PainelEntradaCliente` monta seu combo de circuitos e um circuito tem `ativo=false`
+- **THEN** esse circuito não aparece como opção no combo
+
+#### Scenario: Endpoint REST exclui circuito inativo
+- **WHEN** o endpoint `GET /circuitos` é chamado e um circuito tem `ativo=false`
+- **THEN** esse circuito não está presente na lista retornada
+
+#### Scenario: Editor continua exibindo circuito inativo
+- **WHEN** o usuário navega até um circuito com `ativo=false` pelos botões Anterior/Próximo do editor de circuitos
+- **THEN** o circuito é carregado e fica editável normalmente, apesar de não aparecer nos seletores em jogo
+
+### Requirement: Migração dos circuitos existentes para ativo=true
+Como o valor padrão de `ativo` passa a ser `false`, todo circuito hoje jogável em `src/main/resources/circuitos/*.xml` SHALL ter `ativo=true` definido explicitamente como parte desta mudança, para permanecer selecionável em jogo após a mudança entrar em vigor.
+
+#### Scenario: Circuito existente permanece selecionável após a migração
+- **WHEN** um circuito que já era jogável antes desta mudança é carregado após a migração (com `ativo=true` gravado em seu XML)
+- **THEN** ele continua aparecendo nos seletores solo, multiplayer e no endpoint REST, exatamente como antes da mudança

--- a/openspec/changes/archive/2026-07-02-reformular-editor-circuitos/specs/dev-editor-tools/spec.md
+++ b/openspec/changes/archive/2026-07-02-reformular-editor-circuitos/specs/dev-editor-tools/spec.md
@@ -1,0 +1,48 @@
+## MODIFIED Requirements
+
+### Requirement: Circuit editor persists to source resources
+The circuit editor (`EditorCircuitos` opening `MainPanelEditor`) SHALL default file-open and file-save dialogs for circuit images and circuit XML files to `src/main/resources/circuitos`, resolved relative to the project root working directory, and SHALL NOT default to a directory derived from the runtime classpath location of a compiled class.
+
+#### Scenario: Opening an existing circuit for editing
+- **WHEN** the user navigates to an existing circuit using the "Anterior"/"Próximo" buttons in the circuit editor
+- **THEN** the editor loads the corresponding XML from `src/main/resources/circuitos` (resolved via `circuitos.properties`), without opening a `JFileChooser`
+
+#### Scenario: Creating a new circuit still starts from a background image
+- **WHEN** the user clicks "Criar Nova" and picks a background reference image
+- **THEN** the file chooser opens with `src/main/resources/circuitos` as its starting directory, filtered to image files, exactly as before this change
+
+#### Scenario: Saving a circuit for the first time
+- **WHEN** the user creates or edits a circuit and clicks "Salvar Pista Atual" (or presses F8) without a file already associated
+- **THEN** the save file chooser opens with `src/main/resources/circuitos` as its starting directory, and confirming the dialog writes the circuit XML to the selected path under that directory by default
+
+## ADDED Requirements
+
+### Requirement: Editor de circuitos não usa menu, apenas botões de topo
+O editor de circuitos (`EditorCircuitos`) SHALL NOT exibir um `JMenuBar`; as únicas ações de topo disponíveis SHALL ser os botões "Salvar Pista Atual" e "Criar Nova".
+
+#### Scenario: Menu bar removido
+- **WHEN** a janela do editor de circuitos é aberta
+- **THEN** nenhum `JMenuBar` está presente, e o frame expõe exatamente dois controles de ação de topo: "Salvar Pista Atual" e "Criar Nova"
+
+#### Scenario: Salvar Pista Atual substitui o antigo item de menu
+- **WHEN** o usuário clica em "Salvar Pista Atual"
+- **THEN** o mesmo comportamento de salvamento antes disparado pelo item de menu "Salvar Pista F8" é executado (o atalho de teclado F8 continua disparando a mesma ação)
+
+#### Scenario: Criar Nova substitui o antigo item de menu
+- **WHEN** o usuário clica em "Criar Nova"
+- **THEN** o mesmo fluxo de criação de circuito antes disparado pelo item de menu "Criar Circuito" é executado (escolha de imagem de fundo via file chooser)
+
+### Requirement: Navegação Anterior/Próximo para selecionar circuito existente
+O editor de circuitos SHALL permitir navegar pelos circuitos existentes com controles "Anterior"/"Próximo" alimentados pela lista de `circuitos.properties` (com fallback de varredura de `src/main/resources/circuitos/*.xml` caso a properties não possa ser lida), replicando o padrão de navegação por temporada já usado em `EditorCoresCarros`, em vez de um `JFileChooser` bruto.
+
+#### Scenario: Navegar para o próximo circuito
+- **WHEN** o usuário clica em "Próximo" estando em um circuito que não é o último da lista
+- **THEN** o editor carrega e exibe o próximo circuito da lista ordenada, e o controle "Próximo" fica desabilitado ao alcançar o último circuito
+
+#### Scenario: Navegar para o circuito anterior
+- **WHEN** o usuário clica em "Anterior" estando em um circuito que não é o primeiro da lista
+- **THEN** o editor carrega e exibe o circuito anterior da lista ordenada, e o controle "Anterior" fica desabilitado ao alcançar o primeiro circuito
+
+#### Scenario: Fallback quando circuitos.properties não pode ser lido
+- **WHEN** `properties/circuitos.properties` não pode ser lido
+- **THEN** o editor monta a lista navegável varrendo diretamente os arquivos `src/main/resources/circuitos/*.xml`

--- a/openspec/changes/archive/2026-07-02-reformular-editor-circuitos/specs/objetos-cenario-circuito/spec.md
+++ b/openspec/changes/archive/2026-07-02-reformular-editor-circuitos/specs/objetos-cenario-circuito/spec.md
@@ -1,0 +1,35 @@
+## MODIFIED Requirements
+
+### Requirement: Objetos de cenário ficam numa lista separada, como pista e box
+`Circuito` SHALL manter os objetos de cenário (`ObjetoArquibancada`, `ObjetoConstrucao`, `ObjetoGuardRails`, `ObjetoPneus`) numa lista própria (`objetosCenario`), distinta da lista `objetos` que continua contendo `ObjetoEscapada` e `ObjetoTransparencia`. O editor de circuitos SHALL exibir e gerenciar as listas `objetos` e `objetosCenario` dentro da seção de objetos de um único `JSplitPane` lateral compartilhado com a seção de nós de pista/box (ver requisito "Editor consolida nós e objetos em um único split pane lateral"), em vez de painéis EAST/WEST separados.
+
+#### Scenario: Criar um objeto de cenário adiciona à lista correta
+- **WHEN** o usuário cria um `ObjetoArquibancada`, `ObjetoConstrucao`, `ObjetoGuardRails` ou `ObjetoPneus` pelo editor
+- **THEN** o objeto é adicionado a `circuito.getObjetosCenario()`, e aparece na lista dedicada a objetos de cenário dentro da seção de objetos do split pane, não na lista `objetos`
+
+#### Scenario: Criar Escapada ou Transparência continua indo para a lista objetos
+- **WHEN** o usuário cria um `ObjetoEscapada` ou `ObjetoTransparencia` pelo editor
+- **THEN** o objeto é adicionado a `circuito.getObjetos()`, como antes desta mudança, e aparece na lista `objetos` dentro da mesma seção de objetos do split pane
+
+## ADDED Requirements
+
+### Requirement: Editor consolida nós e objetos em um único split pane lateral
+O editor de circuitos SHALL apresentar as listas de nós (`pistaJList`/`boxJList`) e as listas de objetos de pista (`objetos`/`objetosCenario`) em um único `JSplitPane` posicionado em uma única lateral da janela (não mais em painéis WEST e EAST separados), com uma seção dedicada a nós e outra dedicada a objetos.
+
+#### Scenario: Nós e objetos compartilham a mesma lateral
+- **WHEN** o editor de circuitos é aberto
+- **THEN** as listas de nós e as listas de objetos aparecem dentro do mesmo `JSplitPane`, em uma única lateral da janela, com um divisor ajustável entre a seção de nós e a seção de objetos
+
+### Requirement: Ações de nó ficam agrupadas na seção de nós do split pane
+As ações relativas à edição de nós (inserir nó via clique com tipo selecionado, "Apagar Ultimo NO", "Apaga Nó na lista Selecionada", remoção via tecla Delete na lista) SHALL ficar agrupadas dentro da seção de nós do split pane, em vez de espalhadas em um painel de botões separado (`buttonsPanel`) fora do split pane.
+
+#### Scenario: Botões de ação de nó aparecem junto às listas de nó
+- **WHEN** o usuário abre a seção de nós do split pane
+- **THEN** os controles "Apagar Ultimo NO" e "Apaga Nó na lista Selecionada" estão visíveis dentro dessa seção, junto das listas `pistaJList`/`boxJList`
+
+### Requirement: Ações de objeto ficam agrupadas na seção de objetos do split pane
+As ações relativas a objetos de pista (criar via "Criar Objeto", remover, reordenar via Cima/Baixo/Primeiro/Ultimo, editar) SHALL ficar agrupadas dentro da seção de objetos do split pane, reutilizando `FormularioListaObjetos` para as duas listas (`objetos` e `objetosCenario`), em vez de o botão "Criar Objeto" ficar em um painel de botões separado fora do split pane.
+
+#### Scenario: Botão Criar Objeto aparece junto às listas de objeto
+- **WHEN** o usuário abre a seção de objetos do split pane
+- **THEN** o controle "Criar Objeto" está visível dentro dessa seção, junto das listas `objetos` e `objetosCenario` e seus botões Cima/Baixo/Primeiro/Ultimo/Editar/Remover

--- a/openspec/changes/archive/2026-07-02-reformular-editor-circuitos/tasks.md
+++ b/openspec/changes/archive/2026-07-02-reformular-editor-circuitos/tasks.md
@@ -1,0 +1,48 @@
+## 1. Propriedade `ativo` em `Circuito`
+
+- [x] 1.1 Adicionar campo `private boolean ativo` (default `false`) a `br.f1mane.entidades.Circuito`, com `isAtivo()`/`setAtivo(boolean)` seguindo o padrão JavaBeans já usado por `noite`/`usaBkg`
+- [x] 1.2 Confirmar via teste manual (salvar/carregar um circuito no editor) que `XMLEncoder`/`XMLDecoder` grava e lê a propriedade corretamente, incluindo o caso de XML antigo sem a propriedade (deve carregar como `false`) — verificado com round-trip standalone (encode/decode com e sem a propriedade)
+
+## 2. Migração dos circuitos existentes para `ativo=true`
+
+- [x] 2.1 Levantar a lista completa de arquivos em `src/main/resources/circuitos/*.xml` hoje referenciados em `properties/circuitos.properties` (circuitos jogáveis) — 37 arquivos, todos referenciados
+- [x] 2.2 Editar em lote (script ou edição direta) cada um desses XMLs para incluir `<void property="ativo"><boolean>true</boolean></void>`
+- [x] 2.3 Validar que o número de XMLs com `ativo=true` bate com o número de entradas em `circuitos.properties`, antes de prosseguir para a filtragem em runtime — 37/37
+
+## 3. Filtragem de circuitos inativos em runtime
+
+- [x] 3.1 Ajustar `CarregadorRecursos.carregarCircuitosDefaults()` para pular (`continue`) circuitos com `isAtivo()` falso ao montar a lista de `CircuitosDefault` — resolvido filtrando na fonte (ver 3.2)
+- [x] 3.2 Filtrar na fonte única `ControleRecursos.carregarCircuitos()` (em vez de em cada combo box separadamente): ao montar o cache estático `Map<String,String>`, decodifica cada `Circuito` e pula (`continue`) os que tiverem `isAtivo()` falso. Isso cobre automaticamente todos os consumidores desse cache — `GerenciadorVisual.gerarSeletorCircuito()`, `PainelEntradaCliente`, `PainelMenuLocal`, `MainFrameSimulacao` e `CarregadorRecursos.carregarCircuitosDefaults()` — sem precisar tocar cada um individualmente
+- [x] 3.3 `PainelEntradaCliente` (combo de circuitos do cliente multiplayer) já herda a exclusão por ler `ControleRecursos.carregarCircuitos()` diretamente (`this.circuitos = ControleRecursos.carregarCircuitos()`)
+- [x] 3.4 Confirmar que `LetsRace.circuitos()` (REST `GET /circuitos`) reflete a exclusão por depender de `carregarCircuitosDefaults()` → `ControleRecursos.carregarCircuitos()`
+- [x] 3.5 Verificado programaticamente (sem GUI): `jerez_mro.xml` marcado temporariamente `ativo=false` desaparece de `ControleRecursos.carregarCircuitos()` (36/37 no mapa), fonte única usada por `GerenciadorVisual`, `PainelEntradaCliente` e (via `carregarCircuitosDefaults()`) `LetsRace.circuitos()`; arquivo restaurado para `ativo=true` em seguida. A verificação de que o circuito continua abrível no editor requer sessão gráfica interativa
+
+## 4. Editor: navegação Anterior/Próximo para circuito existente
+
+- [x] 4.1 Implementar `popularCircuitos()` em `MainPanelEditor` lendo `properties/circuitos.properties` (chaves = arquivos XML), com fallback de varredura de `src/main/resources/circuitos/*.xml`, replicando `EditorCoresCarros.popularTemporadas()`
+- [x] 4.2 Adicionar botões "Anterior"/"Próximo" e um label do circuito atual (`gerarTopoNavegacaoEAcoes()`), replicando `navegarTemporada`/`atualizarNavegacaoTemporada` de `EditorCoresCarros`
+- [x] 4.3 Substituir o antigo `MainPanelEditor.editar()` (baseado em `JFileChooser`) por `carregarCircuitoExistente(String)`, carregando via `CarregadorRecursos.carregarCircuito(nomeArquivoXml)` a partir da navegação Anterior/Próximo (`navegarCircuito(delta)`)
+- [x] 4.4 Preservar o fluxo atual de `novo()` (escolha de imagem de fundo via `JFileChooser`) para criação de circuito novo, sem navegação Anterior/Próximo (`indiceCircuito = -1`, label mostra "(novo circuito, não salvo)")
+- [ ] 4.5 Teste manual: abrir o editor, navegar entre pelo menos 3 circuitos existentes com Anterior/Próximo, e confirmar que os controles desabilitam corretamente nas pontas da lista — requer sessão gráfica interativa, não executável neste ambiente headless
+
+## 5. Editor: split pane lateral consolidado (nós + objetos)
+
+- [x] 5.1 Substituir `gerarListsNosPistaBox()` (WEST) e `listasObjetosPanel` (EAST) por um único `JSplitPane` (`gerarSplitPaneLateral()`, orientação vertical) posicionado em uma única lateral (EAST) da janela
+- [x] 5.2 Mover as listas `pistaJList`/`boxJList`, o seletor de tipo de nó (`gerarRadiosTipoNo()`) e os botões "Apagar Ultimo NO"/"Apaga Nó na lista Selecionada" (`gerarBotoesAcoesNo()`) para a seção superior (nós) do split pane (`gerarSecaoNos()`)
+- [x] 5.3 Mover os dois `FormularioListaObjetos` (`objetos`/`objetosCenario`) e o botão "Criar Objeto" (`gerarBotaoCriarObjeto()`) para a seção inferior (objetos) do split pane (`gerarSecaoObjetos()`)
+- [x] 5.4 Remover o antigo `buttonsPanel`/`gerarBotoesTracado()` monolítico; os toggles de visualização (Desenha Traçado/Desenho Background/Créditos) que não são nem ação de nó nem de objeto ficaram em `gerarBotoesVisualizacao()`, no topo (NORTH), fora do split pane
+- [x] 5.5 Definir proporção inicial do divisor (`setResizeWeight(0.5)`) e habilitar arraste (`JSplitPane` é arrastável por padrão; `setOneTouchExpandable(true)` adicionado)
+- [ ] 5.6 Teste manual: inserir um nó pela seção de nós e criar/editar um objeto pela seção de objetos, confirmando que ambas as ações continuam funcionando dentro do novo layout — requer sessão gráfica interativa, não executável neste ambiente headless
+
+## 6. Editor: remoção do menu e botões de topo
+
+- [x] 6.1 Remover `gerarMenusEditor()`/`JMenuBar` de `EditorCircuitos` (também removidos os menus "Informações"/logs/debug/sobre, conforme aceito no design.md)
+- [x] 6.2 Adicionar botões de topo "Salvar Pista Atual" (chama `salvarPista()`) e "Criar Nova" (chama `novo()`) em `gerarTopoNavegacaoEAcoes()`
+- [x] 6.3 Confirmar que o atalho de teclado F8 continua funcionando e chama a mesma ação do botão "Salvar Pista Atual" (`EditorCircuitos.ativarKeysEditor()` inalterado, ainda chama `editor.salvarPista()`)
+- [x] 6.4 Adicionar um checkbox "Ativo" junto aos botões de topo, ligado a `circuito.isAtivo()`/`setAtivo(boolean)`
+- [ ] 6.5 Teste manual: abrir o editor, confirmar ausência de `JMenuBar`, e validar que os dois botões de topo e o checkbox "Ativo" disparam os fluxos corretos — requer sessão gráfica interativa, não executável neste ambiente headless; smoke test de startup sem exceção feito via `java -cp target/classes br.f1mane.editor.EditorCircuitos`
+
+## 7. Verificação final
+
+- [x] 7.1 Rodar `mvn test` e confirmar que a suíte existente continua passando — 138/138 testes passando (`mvn -o test -Ph2`)
+- [ ] 7.2 Exercitar manualmente o fluxo completo: criar um circuito novo (nasce `ativo=false`), editá-lo com o novo split pane, marcar `ativo=true`, salvar, e confirmar que ele passa a aparecer nos seletores em jogo — requer sessão gráfica interativa, não executável neste ambiente headless

--- a/openspec/specs/circuito-ativo/spec.md
+++ b/openspec/specs/circuito-ativo/spec.md
@@ -1,0 +1,44 @@
+# circuito-ativo
+
+## Purpose
+
+Permitir que circuitos sejam marcados como ativos ou inativos, de forma que circuitos inativos permaneçam editáveis no editor de circuitos mas fiquem ocultos das superfícies de seleção de circuito em jogo (solo, multiplayer, endpoint REST).
+
+## Requirements
+
+### Requirement: Circuito tem propriedade ativo com valor padrão false
+`Circuito` SHALL expor uma propriedade booleana `ativo` (`isAtivo()`/`setAtivo(boolean)`), persistida via `XMLEncoder`/`XMLDecoder` do mesmo jeito que `noite`/`usaBkg`, com valor padrão `false` quando não definida explicitamente.
+
+#### Scenario: Circuito recém-criado nasce inativo
+- **WHEN** um novo `Circuito` é criado pelo editor (fluxo "Criar Nova") sem que o usuário marque explicitamente a propriedade ativo
+- **THEN** `circuito.isAtivo()` retorna `false`
+
+#### Scenario: XML sem a propriedade ativo carrega como inativo
+- **WHEN** um arquivo XML de circuito existente é decodificado por `XMLDecoder` e não contém `<void property="ativo">`
+- **THEN** o `Circuito` resultante tem `isAtivo()` retornando `false`, pelo comportamento padrão do construtor sem argumentos
+
+### Requirement: Circuitos inativos não aparecem nos seletores em jogo
+O sistema SHALL excluir circuitos com `isAtivo()` igual a `false` de todas as superfícies de seleção de circuito em jogo — combo solo (`GerenciadorVisual.gerarSeletorCircuito()`), combo do cliente multiplayer (`PainelEntradaCliente`) e endpoint REST `GET /circuitos` (`LetsRace.circuitos()`/`CarregadorRecursos.carregarCircuitosDefaults()`) — mantendo-os abríveis e editáveis no editor de circuitos.
+
+#### Scenario: Seletor solo exclui circuito inativo
+- **WHEN** `GerenciadorVisual.gerarSeletorCircuito()` monta o combo box de circuitos e um circuito tem `ativo=false`
+- **THEN** esse circuito não aparece como opção no combo box
+
+#### Scenario: Cliente multiplayer exclui circuito inativo
+- **WHEN** `PainelEntradaCliente` monta seu combo de circuitos e um circuito tem `ativo=false`
+- **THEN** esse circuito não aparece como opção no combo
+
+#### Scenario: Endpoint REST exclui circuito inativo
+- **WHEN** o endpoint `GET /circuitos` é chamado e um circuito tem `ativo=false`
+- **THEN** esse circuito não está presente na lista retornada
+
+#### Scenario: Editor continua exibindo circuito inativo
+- **WHEN** o usuário navega até um circuito com `ativo=false` pelos botões Anterior/Próximo do editor de circuitos
+- **THEN** o circuito é carregado e fica editável normalmente, apesar de não aparecer nos seletores em jogo
+
+### Requirement: Migração dos circuitos existentes para ativo=true
+Como o valor padrão de `ativo` passa a ser `false`, todo circuito hoje jogável em `src/main/resources/circuitos/*.xml` SHALL ter `ativo=true` definido explicitamente como parte desta mudança, para permanecer selecionável em jogo após a mudança entrar em vigor.
+
+#### Scenario: Circuito existente permanece selecionável após a migração
+- **WHEN** um circuito que já era jogável antes desta mudança é carregado após a migração (com `ativo=true` gravado em seu XML)
+- **THEN** ele continua aparecendo nos seletores solo, multiplayer e no endpoint REST, exatamente como antes da mudança

--- a/openspec/specs/dev-editor-tools/spec.md
+++ b/openspec/specs/dev-editor-tools/spec.md
@@ -33,15 +33,49 @@ Defines the behavior of developer/editor tooling for source-resource editing: th
 - **THEN** the editor loads and displays the previous season in the ordered list, and the "previous season" control is disabled when the first season is reached
 
 ### Requirement: Circuit editor persists to source resources
-The circuit editor (`MainFrameEditor` opening `MainPanelEditor`) SHALL default file-open and file-save dialogs for circuit images and circuit XML files to `src/main/resources/circuitos`, resolved relative to the project root working directory, and SHALL NOT default to a directory derived from the runtime classpath location of a compiled class.
+The circuit editor (`EditorCircuitos` opening `MainPanelEditor`) SHALL default file-open and file-save dialogs for circuit images and circuit XML files to `src/main/resources/circuitos`, resolved relative to the project root working directory, and SHALL NOT default to a directory derived from the runtime classpath location of a compiled class.
 
 #### Scenario: Opening an existing circuit for editing
-- **WHEN** the user selects "Editar Circuito" from the editor menu
-- **THEN** the file chooser opens with `src/main/resources/circuitos` as its starting directory
+- **WHEN** the user navigates to an existing circuit using the "Anterior"/"Próximo" buttons in the circuit editor
+- **THEN** the editor loads the corresponding XML from `src/main/resources/circuitos` (resolved via `circuitos.properties`), without opening a `JFileChooser`
+
+#### Scenario: Creating a new circuit still starts from a background image
+- **WHEN** the user clicks "Criar Nova" and picks a background reference image
+- **THEN** the file chooser opens with `src/main/resources/circuitos` as its starting directory, filtered to image files, exactly as before this change
 
 #### Scenario: Saving a circuit for the first time
-- **WHEN** the user creates or edits a circuit and triggers "Salvar Pista" (F8) without a file already associated
+- **WHEN** the user creates or edits a circuit and clicks "Salvar Pista Atual" (or presses F8) without a file already associated
 - **THEN** the save file chooser opens with `src/main/resources/circuitos` as its starting directory, and confirming the dialog writes the circuit XML to the selected path under that directory by default
+
+### Requirement: Editor de circuitos não usa menu, apenas botões de topo
+O editor de circuitos (`EditorCircuitos`) SHALL NOT exibir um `JMenuBar`; as únicas ações de topo disponíveis SHALL ser os botões "Salvar Pista Atual" e "Criar Nova".
+
+#### Scenario: Menu bar removido
+- **WHEN** a janela do editor de circuitos é aberta
+- **THEN** nenhum `JMenuBar` está presente, e o frame expõe exatamente dois controles de ação de topo: "Salvar Pista Atual" e "Criar Nova"
+
+#### Scenario: Salvar Pista Atual substitui o antigo item de menu
+- **WHEN** o usuário clica em "Salvar Pista Atual"
+- **THEN** o mesmo comportamento de salvamento antes disparado pelo item de menu "Salvar Pista F8" é executado (o atalho de teclado F8 continua disparando a mesma ação)
+
+#### Scenario: Criar Nova substitui o antigo item de menu
+- **WHEN** o usuário clica em "Criar Nova"
+- **THEN** o mesmo fluxo de criação de circuito antes disparado pelo item de menu "Criar Circuito" é executado (escolha de imagem de fundo via file chooser)
+
+### Requirement: Navegação Anterior/Próximo para selecionar circuito existente
+O editor de circuitos SHALL permitir navegar pelos circuitos existentes com controles "Anterior"/"Próximo" alimentados pela lista de `circuitos.properties` (com fallback de varredura de `src/main/resources/circuitos/*.xml` caso a properties não possa ser lida), replicando o padrão de navegação por temporada já usado em `EditorCoresCarros`, em vez de um `JFileChooser` bruto.
+
+#### Scenario: Navegar para o próximo circuito
+- **WHEN** o usuário clica em "Próximo" estando em um circuito que não é o último da lista
+- **THEN** o editor carrega e exibe o próximo circuito da lista ordenada, e o controle "Próximo" fica desabilitado ao alcançar o último circuito
+
+#### Scenario: Navegar para o circuito anterior
+- **WHEN** o usuário clica em "Anterior" estando em um circuito que não é o primeiro da lista
+- **THEN** o editor carrega e exibe o circuito anterior da lista ordenada, e o controle "Anterior" fica desabilitado ao alcançar o primeiro circuito
+
+#### Scenario: Fallback quando circuitos.properties não pode ser lido
+- **WHEN** `properties/circuitos.properties` não pode ser lido
+- **THEN** o editor monta a lista navegável varrendo diretamente os arquivos `src/main/resources/circuitos/*.xml`
 
 ### Requirement: Editor tools are grouped under the editor package
 `EditorCoresCarros` and `MainFrameEditor` SHALL live in the `br.f1mane.editor` package, alongside the other source-resource editing tools (`MainPanelEditor`, `FormularioObjetos`, `FormularioListaObjetos`).

--- a/openspec/specs/objetos-cenario-circuito/spec.md
+++ b/openspec/specs/objetos-cenario-circuito/spec.md
@@ -88,15 +88,36 @@ A lógica de desenho procedural do circuito (traçado de pista, zebra, box e obj
 - **THEN** ambos os desenhos (pista, zebra, box e objetos não excluídos) são produzidos pelo mesmo componente de desenho, não por duas implementações separadas mantidas manualmente em sincronia
 
 ### Requirement: Objetos de cenário ficam numa lista separada, como pista e box
-`Circuito` SHALL manter os objetos de cenário (`ObjetoArquibancada`, `ObjetoConstrucao`, `ObjetoGuardRails`, `ObjetoPneus`) numa lista própria (`objetosCenario`), distinta da lista `objetos` que continua contendo `ObjetoEscapada` e `ObjetoTransparencia`. O editor de circuitos SHALL exibir e gerenciar essa lista num painel separado do painel da lista `objetos`, do mesmo jeito que já existem painéis/listas separados para nós de pista e nós de box.
+`Circuito` SHALL manter os objetos de cenário (`ObjetoArquibancada`, `ObjetoConstrucao`, `ObjetoGuardRails`, `ObjetoPneus`) numa lista própria (`objetosCenario`), distinta da lista `objetos` que continua contendo `ObjetoEscapada` e `ObjetoTransparencia`. O editor de circuitos SHALL exibir e gerenciar as listas `objetos` e `objetosCenario` dentro da seção de objetos de um único `JSplitPane` lateral compartilhado com a seção de nós de pista/box (ver requisito "Editor consolida nós e objetos em um único split pane lateral"), em vez de painéis EAST/WEST separados.
 
 #### Scenario: Criar um objeto de cenário adiciona à lista correta
 - **WHEN** o usuário cria um `ObjetoArquibancada`, `ObjetoConstrucao`, `ObjetoGuardRails` ou `ObjetoPneus` pelo editor
-- **THEN** o objeto é adicionado a `circuito.getObjetosCenario()`, e aparece no painel de lista dedicado a objetos de cenário, não no painel da lista `objetos`
+- **THEN** o objeto é adicionado a `circuito.getObjetosCenario()`, e aparece na lista dedicada a objetos de cenário dentro da seção de objetos do split pane, não na lista `objetos`
 
 #### Scenario: Criar Escapada ou Transparência continua indo para a lista objetos
 - **WHEN** o usuário cria um `ObjetoEscapada` ou `ObjetoTransparencia` pelo editor
-- **THEN** o objeto é adicionado a `circuito.getObjetos()`, como antes desta mudança, e aparece no painel de lista existente
+- **THEN** o objeto é adicionado a `circuito.getObjetos()`, como antes desta mudança, e aparece na lista `objetos` dentro da mesma seção de objetos do split pane
+
+### Requirement: Editor consolida nós e objetos em um único split pane lateral
+O editor de circuitos SHALL apresentar as listas de nós (`pistaJList`/`boxJList`) e as listas de objetos de pista (`objetos`/`objetosCenario`) em um único `JSplitPane` posicionado em uma única lateral da janela (não mais em painéis WEST e EAST separados), com uma seção dedicada a nós e outra dedicada a objetos.
+
+#### Scenario: Nós e objetos compartilham a mesma lateral
+- **WHEN** o editor de circuitos é aberto
+- **THEN** as listas de nós e as listas de objetos aparecem dentro do mesmo `JSplitPane`, em uma única lateral da janela, com um divisor ajustável entre a seção de nós e a seção de objetos
+
+### Requirement: Ações de nó ficam agrupadas na seção de nós do split pane
+As ações relativas à edição de nós (inserir nó via clique com tipo selecionado, "Apagar Ultimo NO", "Apaga Nó na lista Selecionada", remoção via tecla Delete na lista) SHALL ficar agrupadas dentro da seção de nós do split pane, em vez de espalhadas em um painel de botões separado (`buttonsPanel`) fora do split pane.
+
+#### Scenario: Botões de ação de nó aparecem junto às listas de nó
+- **WHEN** o usuário abre a seção de nós do split pane
+- **THEN** os controles "Apagar Ultimo NO" e "Apaga Nó na lista Selecionada" estão visíveis dentro dessa seção, junto das listas `pistaJList`/`boxJList`
+
+### Requirement: Ações de objeto ficam agrupadas na seção de objetos do split pane
+As ações relativas a objetos de pista (criar via "Criar Objeto", remover, reordenar via Cima/Baixo/Primeiro/Ultimo, editar) SHALL ficar agrupadas dentro da seção de objetos do split pane, reutilizando `FormularioListaObjetos` para as duas listas (`objetos` e `objetosCenario`), em vez de o botão "Criar Objeto" ficar em um painel de botões separado fora do split pane.
+
+#### Scenario: Botão Criar Objeto aparece junto às listas de objeto
+- **WHEN** o usuário abre a seção de objetos do split pane
+- **THEN** o controle "Criar Objeto" está visível dentro dessa seção, junto das listas `objetos` e `objetosCenario` e seus botões Cima/Baixo/Primeiro/Ultimo/Editar/Remover
 
 ### Requirement: Menu de contexto para ajuste rápido de objeto
 Ao clicar com o botão direito sobre um objeto (de qualquer uma das duas listas) no editor de circuitos, o sistema SHALL exibir um menu de contexto com controles para largura, altura e ângulo de rotação, que gravam a alteração diretamente no objeto e atualizam o desenho, sem exigir abrir o formulário modal completo.

--- a/src/main/java/br/f1mane/controles/ControleRecursos.java
+++ b/src/main/java/br/f1mane/controles/ControleRecursos.java
@@ -265,6 +265,14 @@ public abstract class ControleRecursos {
             while (propName.hasMoreElements()) {
                 final String name = (String) propName.nextElement();
                 String names[] = properties.getProperty(name).split(",");
+                try {
+                    if (!CarregadorRecursos.carregarCircuito(name).isAtivo()) {
+                        continue;
+                    }
+                } catch (Exception e) {
+                    Logger.logarExept(e);
+                    continue;
+                }
                 circuitos.put(names[0], name);
                 circuitosCiclo.put(names[0],Integer.valueOf(names[1]));
             }

--- a/src/main/java/br/f1mane/editor/EditorCircuitos.java
+++ b/src/main/java/br/f1mane/editor/EditorCircuitos.java
@@ -1,35 +1,18 @@
 package br.f1mane.editor;
 
-import java.awt.Container;
-import java.awt.Graphics;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.awt.event.KeyAdapter;
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
 import java.awt.event.MouseListener;
 import java.awt.event.MouseWheelListener;
-import java.awt.image.BufferedImage;
-import java.io.File;
 import java.io.IOException;
-import java.util.Iterator;
-import java.util.Set;
 
 import javax.swing.JFrame;
-import javax.swing.JMenu;
-import javax.swing.JMenuBar;
-import javax.swing.JMenuItem;
 import javax.swing.JOptionPane;
-import javax.swing.JPanel;
-import javax.swing.JScrollPane;
-import javax.swing.JTextArea;
 import javax.swing.WindowConstants;
 
 import br.f1mane.controles.InterfaceJogo;
 import br.f1mane.recursos.CarregadorRecursos;
-import br.nnpe.Global;
-import br.nnpe.ImageUtil;
-import br.nnpe.Logger;
 
 /**
  * @author Paulo Sobreira Created on 14/06/2014
@@ -41,9 +24,6 @@ public class EditorCircuitos extends JFrame {
     private static final long serialVersionUID = -284357233387917389L;
     private MainPanelEditor editor;
     private InterfaceJogo controleJogo;
-    private final JMenuBar bar;
-    private final JMenu menuEditor;
-    private final JMenu menuInfo;
 
     protected boolean altApertado;
     protected boolean shiftApertado;
@@ -53,93 +33,25 @@ public class EditorCircuitos extends JFrame {
     }
 
     public EditorCircuitos() throws IOException {
-        bar = new JMenuBar();
-        this.setJMenuBar(bar);
-
-        menuEditor = new JMenu("Editor");
-        bar.add(menuEditor);
-
-        menuInfo = new JMenu("Informações");
-        bar.add(menuInfo);
-
-        gerarMenusEditor(menuEditor);
-        gerarMenusInfo(menuInfo);
-        gerarMenusSobre(menuInfo);
         String title = "Fl-MANE " + getVersao() + " MANager & Engineer Editor";
         setTitle(title);
         removerListeners();
         removerKeyListeners();
         setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
-        final BufferedImage bg = ImageUtil.gerarFade(carregarBgAleatorio(), 25);
-        setSize(bg != null ? bg.getWidth() : 1024, bg != null ? bg.getHeight() : 768);
-        JPanel jPanel = new JPanel() {
-            @Override
-            protected void paintComponent(Graphics g) {
-                super.paintComponent(g);
-                g.drawImage(bg, 0, 0, null);
-            }
-        };
-        getContentPane().add(jPanel);
-        this.setVisible(true);
-
-    }
-
-    private BufferedImage carregarBgAleatorio() {
+        setSize(1024, 768);
         try {
-            java.net.URL dir = CarregadorRecursos.class.getResource("/bg");
-            if (dir != null) {
-                File pasta = new File(dir.toURI());
-                File[] jpgs = pasta.listFiles(f -> f.getName().endsWith(".jpg"));
-                if (jpgs != null && jpgs.length > 0) {
-                    File escolhido = jpgs[new java.util.Random().nextInt(jpgs.length)];
-                    return javax.imageio.ImageIO.read(escolhido);
-                }
-            }
-        } catch (Exception e) {
-            Logger.logarExept(e);
+            editor = new MainPanelEditor(this);
+            editor.iniciarComNavegacao();
+            ativarKeysEditor();
+        } catch (Exception e1) {
+            e1.printStackTrace();
+            dialogDeErro(e1);
         }
-        return new BufferedImage(1024, 768, BufferedImage.TYPE_INT_RGB);
+        this.setVisible(true);
     }
 
     private String getVersao() {
         return CarregadorRecursos.getVersaoFormatado();
-    }
-
-    private void gerarMenusInfo(JMenu menuInfo2) {
-        JMenuItem logs = new JMenuItem("Ver Logs");
-        logs.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent e) {
-                try {
-                    JTextArea area = new JTextArea(20, 50);
-                    Set top = Logger.topExceptions.keySet();
-                    for (Iterator iterator = top.iterator(); iterator.hasNext(); ) {
-                        String exept = (String) iterator.next();
-                        area.append("Quantidade : "
-                                + Logger.topExceptions.get(exept));
-                        area.append("\n");
-                        area.append(exept.replaceAll("<br>", "\n"));
-                        area.append("\n");
-                    }
-                    area.setCaretPosition(0);
-                    JOptionPane.showMessageDialog(EditorCircuitos.this,
-                            new JScrollPane(area), "Lista de Erros",
-                            JOptionPane.INFORMATION_MESSAGE);
-                } catch (Exception ex) {
-                    ex.printStackTrace();
-                    dialogDeErro(ex);
-                }
-            }
-        });
-        menuInfo2.add(logs);
-
-        JMenuItem ligarLogs = new JMenuItem("Ativar Debug/Logs");
-        ligarLogs.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent e) {
-                Global.DEBUG = !Global.DEBUG;
-            }
-        });
-        menuInfo2.add(ligarLogs);
-
     }
 
     public void dialogDeErro(Exception e) {
@@ -152,28 +64,6 @@ public class EditorCircuitos extends JFrame {
         JOptionPane.showMessageDialog(null, retorno.toString(),
                 "Conexão Perdida. Erro enviando dados.", JOptionPane.ERROR_MESSAGE);
 
-    }
-
-    private void gerarMenusSobre(JMenu menu2) {
-        JMenuItem sobre = new JMenuItem("Sobre o autor do jogo");
-        sobre.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent e) {
-                mostraSobre();
-            }
-
-        });
-        menu2.add(sobre);
-    }
-
-    public void mostraSobre() {
-        String msg = "Feito por" + " Paulo Sobreira        ".trim() + "\n"
-                + "- " + "Pistas" + " "
-                + "- " + "Capacetes e Carros" + " "
-                + "- https://sowbreira-26fe1.firebaseapp.com             ".trim() + "\n"
-                + "- sowbreira@gmail.com                       ".trim() + "\n"
-                + "- 2007-2026";
-        JOptionPane.showMessageDialog(EditorCircuitos.this, msg,
-                "Sobre o autor do jogo", JOptionPane.INFORMATION_MESSAGE);
     }
 
     private void ativarKeysEditor() {
@@ -253,58 +143,6 @@ public class EditorCircuitos extends JFrame {
         for (int i = 0; i < listeners.length; i++) {
             removeKeyListener(listeners[i]);
         }
-    }
-
-    private void gerarMenusEditor(Container menu4) {
-
-        JMenuItem abrirImg = new JMenuItem("Criar Circuito");
-        abrirImg.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent e) {
-                try {
-                    if (controleJogo != null) {
-                        controleJogo.matarTodasThreads();
-                    }
-                    editor = new MainPanelEditor(
-                            EditorCircuitos.this);
-                    editor.novo();
-                    ativarKeysEditor();
-                } catch (Exception e1) {
-                    e1.printStackTrace();
-                    dialogDeErro(e1);
-                }
-            }
-        });
-        menu4.add(abrirImg);
-        JMenuItem abrirPista = new JMenuItem("Editar Circuito");
-        abrirPista.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent e) {
-                try {
-                    if (controleJogo != null) {
-                        controleJogo.matarTodasThreads();
-                    }
-                    editor = new MainPanelEditor(EditorCircuitos.this);
-                    editor.editar();
-                    ativarKeysEditor();
-                } catch (Exception e1) {
-                    e1.printStackTrace();
-                    dialogDeErro(e1);
-                }
-            }
-        });
-        menu4.add(abrirPista);
-
-        JMenuItem salvarPista = new JMenuItem("Salvar Pista F8");
-        salvarPista.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent e) {
-                try {
-                    editor.salvarPista();
-                } catch (Exception e1) {
-                    e1.printStackTrace();
-                }
-            }
-        });
-        menu4.add(salvarPista);
-
     }
 
     public static void main(String[] args) throws IOException {

--- a/src/main/java/br/f1mane/editor/MainPanelEditor.java
+++ b/src/main/java/br/f1mane/editor/MainPanelEditor.java
@@ -30,13 +30,18 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
 
 import javax.swing.BorderFactory;
-import javax.swing.ButtonGroup;
 import javax.swing.DefaultListCellRenderer;
 import javax.swing.DefaultListModel;
 import javax.swing.JButton;
@@ -50,9 +55,9 @@ import javax.swing.JList;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JPopupMenu;
-import javax.swing.JRadioButton;
 import javax.swing.JScrollPane;
 import javax.swing.JSpinner;
+import javax.swing.JSplitPane;
 import javax.swing.JTextField;
 import javax.swing.ListCellRenderer;
 import javax.swing.SpinnerNumberModel;
@@ -90,7 +95,7 @@ public class MainPanelEditor extends JPanel {
     private JList boxJList;
     private EditorCircuitos srcFrame;
     private boolean desenhaTracado = true;
-    private boolean mostraBG = true;
+    private boolean mostraBG = false;
     private boolean creditos = false;
     private boolean pontosEscape = false;
     public final static Color oran = new Color(255, 188, 40, 180);
@@ -100,16 +105,37 @@ public class MainPanelEditor extends JPanel {
     int ultimoItemBoxSelecionado = -1;
     int ultimoItemPistaSelecionado = -1;
 
-    private final JRadioButton largadaButton = new JRadioButton();
-    private final JRadioButton retaButton = new JRadioButton();
-    private final JRadioButton curvaAltaButton = new JRadioButton();
-    private final JRadioButton curvaBaixaButton = new JRadioButton();
-    private final JRadioButton boxButton = new JRadioButton();
-    private final JRadioButton boxRetaButton = new JRadioButton();
-    private final JRadioButton boxCurvaAltaButton = new JRadioButton();
-    private final JRadioButton paraBoxButton = new JRadioButton();
-    private final JRadioButton fimBoxButton = new JRadioButton();
-    private final JRadioButton semSelecaoButton = new JRadioButton();
+    private static final class OpcaoTipoNo {
+        final String label;
+        final Color tipo;
+        final boolean box;
+
+        OpcaoTipoNo(String label, Color tipo, boolean box) {
+            this.label = label;
+            this.tipo = tipo;
+            this.box = box;
+        }
+
+        @Override
+        public String toString() {
+            return label;
+        }
+    }
+
+    private static final OpcaoTipoNo[] TIPOS_NO = new OpcaoTipoNo[]{
+            new OpcaoTipoNo("Sem seleção", null, false),
+            new OpcaoTipoNo("No Largada", No.LARGADA, false),
+            new OpcaoTipoNo("No Reta", No.RETA, false),
+            new OpcaoTipoNo("No Curva Alta", No.CURVA_ALTA, false),
+            new OpcaoTipoNo("No Curva Baixa", No.CURVA_BAIXA, false),
+            new OpcaoTipoNo("No Box", No.BOX, true),
+            new OpcaoTipoNo("No Reta Box", No.RETA, true),
+            new OpcaoTipoNo("No Curva Box", No.CURVA_ALTA, true),
+            new OpcaoTipoNo("No Parada Box", No.PARADA_BOX, true),
+            new OpcaoTipoNo("No Fim Box", No.FIM_BOX, true),
+    };
+
+    private JComboBox tipoNoCombo;
 
     private JScrollPane scrollPane;
 
@@ -146,6 +172,14 @@ public class MainPanelEditor extends JPanel {
     private final JLabel corFundoLabel = criaIndicadorDeCor();
     private final JLabel corAsfaltoLabel = criaIndicadorDeCor();
     File file;
+
+    private final List<String> circuitosXml = new ArrayList<String>();
+    private int indiceCircuito = -1;
+    private JLabel lblCircuitoAtual;
+    private JButton btnCircuitoAnterior;
+    private JButton btnCircuitoProximo;
+    private JCheckBox ativoCheckBox;
+    private boolean eventosMouseAdicionados;
 
     public MainPanelEditor() {
     }
@@ -228,96 +262,65 @@ public class MainPanelEditor extends JPanel {
                 new java.awt.Color(60, 60, 60), new java.awt.Color(120, 120, 120),
                 br.f1mane.recursos.SpriteSheet.CIMA_W, br.f1mane.recursos.SpriteSheet.CIMA_H);
 
-        JPanel controlPanel = gerarListsNosPistaBox();
-
-        JPanel buttonsPanel = gerarBotoesTracado();
-
-        JPanel radiosPanel = new JPanel();
-        radiosPanel.setLayout(new GridLayout(1, 10));
-
-        ButtonGroup buttonGroup = new ButtonGroup();
-
-        buttonGroup.add(largadaButton);
-        buttonGroup.add(retaButton);
-        buttonGroup.add(curvaAltaButton);
-        buttonGroup.add(curvaBaixaButton);
-        buttonGroup.add(boxButton);
-        buttonGroup.add(boxRetaButton);
-        buttonGroup.add(boxCurvaAltaButton);
-        buttonGroup.add(paraBoxButton);
-        buttonGroup.add(fimBoxButton);
-        buttonGroup.add(semSelecaoButton);
-        semSelecaoButton.setSelected(true);
-
-        JPanel bottonsPanel = new JPanel();
-        bottonsPanel.add(new JLabel("No Largada"));
-        bottonsPanel.add(largadaButton);
-        radiosPanel.add(bottonsPanel);
-
-        bottonsPanel = new JPanel();
-        bottonsPanel.add(new JLabel("No Reta"));
-        bottonsPanel.add(retaButton);
-        radiosPanel.add(bottonsPanel);
-
-        bottonsPanel = new JPanel();
-        bottonsPanel.add(new JLabel("No Curva Alta"));
-        bottonsPanel.add(curvaAltaButton);
-        radiosPanel.add(bottonsPanel);
-
-        bottonsPanel = new JPanel();
-        bottonsPanel.add(new JLabel("No Curva Baixa"));
-        bottonsPanel.add(curvaBaixaButton);
-        radiosPanel.add(bottonsPanel);
-
-        bottonsPanel = new JPanel();
-        bottonsPanel.add(new JLabel("No Box"));
-        bottonsPanel.add(boxButton);
-        radiosPanel.add(bottonsPanel);
-
-        bottonsPanel = new JPanel();
-        bottonsPanel.add(new JLabel("No Reta Box"));
-        bottonsPanel.add(boxRetaButton);
-        radiosPanel.add(bottonsPanel);
-
-        bottonsPanel = new JPanel();
-        bottonsPanel.add(new JLabel("No Curva Box"));
-        bottonsPanel.add(boxCurvaAltaButton);
-        radiosPanel.add(bottonsPanel);
-
-        bottonsPanel = new JPanel();
-        bottonsPanel.add(new JLabel("No Parada Box"));
-        bottonsPanel.add(paraBoxButton);
-        radiosPanel.add(bottonsPanel);
-
-        bottonsPanel = new JPanel();
-        bottonsPanel.add(new JLabel("No Fim box"));
-        bottonsPanel.add(fimBoxButton);
-        radiosPanel.add(bottonsPanel);
-
-        gerarLayout(srcFrame, controlPanel, buttonsPanel, radiosPanel);
+        gerarLayout(srcFrame);
         testePista = new TestePista(this, circuito);
         adicionaEventosMouse(srcFrame);
     }
 
-    private JPanel gerarBotoesTracado() {
+    private JPanel gerarComboTipoNo() {
+        JPanel painel = new JPanel();
+        painel.add(new JLabel("Tipo de nó"));
+        tipoNoCombo = new JComboBox(TIPOS_NO);
+        tipoNoCombo.setSelectedIndex(0);
+        painel.add(tipoNoCombo);
+        return painel;
+    }
+
+    private JPanel gerarBotoesVisualizacao() {
         JPanel buttonsPanel = new JPanel();
         buttonsPanel.setLayout(new GridLayout(1, 3));
 
-        JButton desenhaTracadoBot = new JButton("Desenha Tracado");
-        desenhaTracadoBot.addActionListener(new ActionListener() {
+        JCheckBox desenhaTracadoCheck = new JCheckBox("Traçado");
+        desenhaTracadoCheck.setSelected(desenhaTracado);
+        desenhaTracadoCheck.addActionListener(new ActionListener() {
             public void actionPerformed(ActionEvent e) {
-                desenhaTracado = !desenhaTracado;
+                desenhaTracado = desenhaTracadoCheck.isSelected();
                 MainPanelEditor.this.repaint();
             }
         });
 
-        JButton desenhaBackgroundBot = new JButton("Desenho Background");
-        desenhaBackgroundBot.addActionListener(new ActionListener() {
+        JCheckBox desenhaBackgroundCheck = new JCheckBox("Background");
+        desenhaBackgroundCheck.setSelected(mostraBG);
+        desenhaBackgroundCheck.addActionListener(new ActionListener() {
             public void actionPerformed(ActionEvent e) {
-                mostraBG = !mostraBG;
+                mostraBG = desenhaBackgroundCheck.isSelected();
                 MainPanelEditor.this.repaint();
             }
         });
+
+        JButton creditosButton = new JButton("Créditos");
+        creditosButton.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent e) {
+                try {
+                    JOptionPane.showMessageDialog(null, "Informe a posição dos créditos na imagem do circuito.",
+                            "Informações", JOptionPane.INFORMATION_MESSAGE);
+                    creditos();
+                } catch (Exception e1) {
+                    e1.printStackTrace();
+                    srcFrame.dialogDeErro(e1);
+                }
+            }
+        });
+
+        buttonsPanel.add(desenhaTracadoCheck);
+        buttonsPanel.add(desenhaBackgroundCheck);
+        buttonsPanel.add(creditosButton);
+        return buttonsPanel;
+    }
+
+    private JPanel gerarBotoesAcoesNo() {
+        JPanel buttonsPanel = new JPanel();
+        buttonsPanel.setLayout(new GridLayout(1, 2));
 
         JButton apagarUltimoNoButton = new JButton("Apagar Ultimo NO");
         apagarUltimoNoButton.addActionListener(new ActionListener() {
@@ -330,7 +333,6 @@ public class MainPanelEditor extends JPanel {
                 }
             }
         });
-
         buttonsPanel.add(apagarUltimoNoButton);
 
         JButton apagaNoListaButton = new JButton("Apaga Nó na lista Selecionada");
@@ -357,12 +359,17 @@ public class MainPanelEditor extends JPanel {
                 }
             }
         });
+        buttonsPanel.add(apagaNoListaButton);
+        return buttonsPanel;
+    }
 
+    private JPanel gerarBotaoCriarObjeto() {
+        JPanel buttonsPanel = new JPanel(new GridLayout(1, 1));
         JButton criarObjeto = new JButton("Criar Objeto");
         criarObjeto.addActionListener(new ActionListener() {
             public void actionPerformed(ActionEvent e) {
                 try {
-                    semSelecaoButton.setSelected(true);
+                    desSelecionaNosPista();
                     FormularioObjetos formularioObjetos = new FormularioObjetos(MainPanelEditor.this);
                     formularioObjetos.mostrarPainelModal();
                     TipoObjetoPista tipoSelecionado = (TipoObjetoPista) formularioObjetos
@@ -383,26 +390,342 @@ public class MainPanelEditor extends JPanel {
 
             }
         });
-        JButton creditosButton = new JButton("Créditos");
-        creditosButton.addActionListener(new ActionListener() {
+        buttonsPanel.add(criarObjeto);
+        return buttonsPanel;
+    }
+
+    private JPanel gerarSecaoNos() {
+        JPanel secao = new JPanel(new BorderLayout());
+        JPanel topo = new JPanel(new GridLayout(3, 1));
+        topo.add(gerarComboTipoNo());
+        topo.add(gerarCombosLadoBox());
+        topo.add(gerarBotoesAcoesNo());
+        secao.add(topo, BorderLayout.NORTH);
+        secao.add(gerarListsNosPistaBox(), BorderLayout.CENTER);
+        return secao;
+    }
+
+    private JPanel gerarCombosLadoBox() {
+        JPanel painel = new JPanel();
+
+        ladoBoxCombo = new JComboBox();
+        ladoBoxCombo.addItem(LADO_COMBO_1);
+        ladoBoxCombo.addItem(LADO_COMBO_2);
+        if (circuito != null && circuito.getLadoBox() == 2) {
+            ladoBoxCombo.setSelectedItem(LADO_COMBO_2);
+        }
+        painel.add(ladoBoxCombo);
+
+        ladoBoxSaidaBoxCombo = new JComboBox();
+        ladoBoxSaidaBoxCombo.addItem(SAIDA_LADO_COMBO_1);
+        ladoBoxSaidaBoxCombo.addItem(SAIDA_LADO_COMBO_2);
+        if (circuito != null && circuito.getLadoBoxSaidaBox() == 2) {
+            ladoBoxSaidaBoxCombo.setSelectedItem(SAIDA_LADO_COMBO_2);
+        }
+        painel.add(ladoBoxSaidaBoxCombo);
+
+        return painel;
+    }
+
+    private JPanel gerarSecaoObjetos() {
+        JPanel secao = new JPanel(new BorderLayout());
+        secao.add(gerarBotaoCriarObjeto(), BorderLayout.NORTH);
+        formularioListaObjetos = new FormularioListaObjetos(this);
+        formularioListaObjetos.listarObjetos();
+        formularioListaObjetosCenario = new FormularioListaObjetos(this, Circuito::getObjetosCenario);
+        formularioListaObjetosCenario.listarObjetos();
+        JPanel listasObjetosPanel = new JPanel(new GridLayout(2, 1));
+        listasObjetosPanel.add(formularioListaObjetos.getObjetos());
+        listasObjetosPanel.add(formularioListaObjetosCenario.getObjetos());
+        secao.add(listasObjetosPanel, BorderLayout.CENTER);
+        return secao;
+    }
+
+    private JSplitPane gerarSplitPaneLateral() {
+        JSplitPane splitPane = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, gerarSecaoNos(), gerarSecaoObjetos());
+        splitPane.setResizeWeight(0.5);
+        splitPane.setOneTouchExpandable(true);
+        splitPane.setPreferredSize(new Dimension(300, 10000));
+        return splitPane;
+    }
+
+
+    private JPanel gerarTopoNavegacaoEAcoes() {
+        JPanel topo = new JPanel(new java.awt.FlowLayout(java.awt.FlowLayout.LEFT, 10, 6)) {
+            @Override
+            public Dimension getPreferredSize() {
+                Dimension d = super.getPreferredSize();
+                return new Dimension(d.width, (int) (d.height * 0.8));
+            }
+        };
+
+        btnCircuitoAnterior = new JButton("◀");
+        btnCircuitoAnterior.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent e) {
+                navegarCircuito(-1);
+            }
+        });
+        topo.add(btnCircuitoAnterior);
+
+        lblCircuitoAtual = new JLabel();
+        topo.add(lblCircuitoAtual);
+
+        btnCircuitoProximo = new JButton("▶");
+        btnCircuitoProximo.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent e) {
+                navegarCircuito(1);
+            }
+        });
+        topo.add(btnCircuitoProximo);
+
+        JButton btnSalvar = new JButton("Salvar");
+        btnSalvar.addActionListener(new ActionListener() {
             public void actionPerformed(ActionEvent e) {
                 try {
-                    JOptionPane.showMessageDialog(null, "Informe a posição dos créditos na imagem do circuito.",
-                            "Informações", JOptionPane.INFORMATION_MESSAGE);
-                    creditos();
-                } catch (Exception e1) {
-                    e1.printStackTrace();
-                    srcFrame.dialogDeErro(e1);
+                    salvarPista();
+                } catch (Exception ex) {
+                    ex.printStackTrace();
+                    srcFrame.dialogDeErro(ex);
                 }
             }
         });
+        topo.add(btnSalvar);
 
-        buttonsPanel.add(apagaNoListaButton);
-        buttonsPanel.add(desenhaTracadoBot);
-        buttonsPanel.add(desenhaBackgroundBot);
-        buttonsPanel.add(creditosButton);
-        buttonsPanel.add(criarObjeto);
-        return buttonsPanel;
+        JButton btnCriarNova = new JButton("Nova");
+        btnCriarNova.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent e) {
+                try {
+                    novo();
+                } catch (Exception ex) {
+                    ex.printStackTrace();
+                    srcFrame.dialogDeErro(ex);
+                }
+            }
+        });
+        topo.add(btnCriarNova);
+
+        topo.add(new JLabel("Nome do circuito"));
+        nomePistaText = new JTextField() {
+            @Override
+            public Dimension getPreferredSize() {
+                return new Dimension(150, 40);
+            }
+        };
+        if (circuito != null) {
+            nomePistaText.setText(circuito.getNome());
+        }
+        topo.add(nomePistaText);
+
+        topo.add(new JLabel("Ativo"));
+        ativoCheckBox = new JCheckBox();
+        ativoCheckBox.setSelected(circuito != null && circuito.isAtivo());
+        ativoCheckBox.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent e) {
+                circuito.setAtivo(ativoCheckBox.isSelected());
+            }
+        });
+        topo.add(ativoCheckBox);
+
+        topo.add(new JLabel() {
+            @Override
+            public String getText() {
+                return "% Chuva";
+            }
+        });
+        probalidadeChuvaText = new JTextField() {
+            @Override
+            public Dimension getPreferredSize() {
+                return new Dimension(30, super.getPreferredSize().height);
+            }
+        };
+        if (circuito != null) {
+            probalidadeChuvaText.setText("" + circuito.getProbalidadeChuva());
+        }
+        topo.add(probalidadeChuvaText);
+
+        if (multiplicadorLarguraPista < 1.0) {
+            multiplicadorLarguraPista = 1.0;
+        }
+        if (multiplicadorLarguraPista > 2.0) {
+            multiplicadorLarguraPista = 2.0;
+        }
+        SpinnerNumberModel model1 = new SpinnerNumberModel(multiplicadorLarguraPista, 1.0, 2.0, 0.1);
+        larguraPistaSpinner = new JSpinner(model1) {
+            @Override
+            public Dimension getPreferredSize() {
+                return new Dimension(60, super.getPreferredSize().height);
+            }
+        };
+        larguraPistaSpinner.addChangeListener(new ChangeListener() {
+            @Override
+            public void stateChanged(ChangeEvent e) {
+                circuito.setMultiplicadorLarguraPista(((Double) larguraPistaSpinner.getModel().getValue()).doubleValue());
+                vetorizarCircuito();
+                repaint();
+            }
+        });
+        topo.add(new JLabel() {
+            @Override
+            public String getText() {
+                return "Largura";
+            }
+        });
+        topo.add(larguraPistaSpinner);
+
+        topo.add(new JLabel("Noite") {
+            @Override
+            public String getText() {
+                return "Noite";
+            }
+        });
+        noite.addChangeListener(new ChangeListener() {
+            @Override
+            public void stateChanged(ChangeEvent e) {
+                circuito.setNoite(noite.isSelected());
+                repaint();
+            }
+        });
+        topo.add(noite);
+
+        topo.add(new JLabel("Cor de Fundo"));
+        atualizaCorLabel(corFundoLabel, circuito != null ? circuito.getCorFundo() : null, Color.WHITE);
+        corFundoLabel.addMouseListener(new MouseAdapter() {
+            public void mouseClicked(MouseEvent e) {
+                Color nova = JColorChooser.showDialog(MainPanelEditor.this,
+                        "Cor de Fundo", corFundoLabel.getBackground());
+                if (nova != null) {
+                    circuito.setCorFundo(nova);
+                    atualizaCorLabel(corFundoLabel, nova, Color.WHITE);
+                    repaint();
+                }
+            }
+        });
+        topo.add(corFundoLabel);
+
+        topo.add(new JLabel("Cor do Asfalto"));
+        atualizaCorLabel(corAsfaltoLabel, circuito != null ? circuito.getCorAsfalto() : null,
+                DesenhoProceduralCircuito.COR_PISTA);
+        corAsfaltoLabel.addMouseListener(new MouseAdapter() {
+            public void mouseClicked(MouseEvent e) {
+                Color nova = JColorChooser.showDialog(MainPanelEditor.this,
+                        "Cor do Asfalto", corAsfaltoLabel.getBackground());
+                if (nova != null) {
+                    circuito.setCorAsfalto(nova);
+                    atualizaCorLabel(corAsfaltoLabel, nova, DesenhoProceduralCircuito.COR_PISTA);
+                    repaint();
+                }
+            }
+        });
+        topo.add(corAsfaltoLabel);
+
+        atualizarBotoesNavegacao();
+        return topo;
+    }
+
+    private void atualizarBotoesNavegacao() {
+        boolean temCircuito = indiceCircuito >= 0 && indiceCircuito < circuitosXml.size();
+        if (btnCircuitoAnterior != null) {
+            btnCircuitoAnterior.setEnabled(temCircuito && indiceCircuito > 0);
+        }
+        if (btnCircuitoProximo != null) {
+            btnCircuitoProximo.setEnabled(temCircuito && indiceCircuito < circuitosXml.size() - 1);
+        }
+        if (lblCircuitoAtual != null) {
+            lblCircuitoAtual.setText(temCircuito ? circuitosXml.get(indiceCircuito) : "—");
+        }
+    }
+
+    private void popularCircuitos() {
+        circuitosXml.clear();
+        try {
+            Properties p = new Properties();
+            InputStream is = CarregadorRecursos.recursoComoStream("properties/circuitos.properties");
+            if (is != null) {
+                p.load(new InputStreamReader(is, StandardCharsets.UTF_8));
+                List<String> arquivos = new ArrayList<String>();
+                for (Object k : p.stringPropertyNames()) {
+                    arquivos.add((String) k);
+                }
+                Collections.sort(arquivos);
+                circuitosXml.addAll(arquivos);
+            }
+        } catch (Exception ex) {
+            File dir = new File("src/main/resources/circuitos");
+            if (dir.isDirectory()) {
+                List<String> arquivos = new ArrayList<String>();
+                for (File f : Objects.requireNonNull(dir.listFiles())) {
+                    if (f.isFile() && f.getName().endsWith(".xml")) {
+                        arquivos.add(f.getName());
+                    }
+                }
+                Collections.sort(arquivos);
+                circuitosXml.addAll(arquivos);
+            }
+        }
+    }
+
+    public void navegarCircuito(int delta) {
+        int novoIndice = indiceCircuito + delta;
+        if (novoIndice < 0 || novoIndice >= circuitosXml.size()) {
+            return;
+        }
+        indiceCircuito = novoIndice;
+        String arquivo = circuitosXml.get(indiceCircuito);
+        try {
+            carregarCircuitoExistente(arquivo);
+        } catch (Exception e) {
+            e.printStackTrace();
+            srcFrame.dialogDeErro(e);
+        }
+    }
+
+    public void iniciarComNavegacao() {
+        popularCircuitos();
+        if (!circuitosXml.isEmpty()) {
+            indiceCircuito = 0;
+            String arquivo = circuitosXml.get(indiceCircuito);
+            try {
+                carregarCircuitoExistente(arquivo);
+                return;
+            } catch (Exception e) {
+                e.printStackTrace();
+                srcFrame.dialogDeErro(e);
+            }
+        }
+        indiceCircuito = -1;
+        testePista = new TestePista(this, circuito);
+        iniciaEditor();
+        atualizaListas();
+        srcFrame.pack();
+        srcFrame.setExtendedState(JFrame.MAXIMIZED_BOTH);
+    }
+
+    private void carregarCircuitoExistente(String arquivoXml) throws IOException, ClassNotFoundException {
+        file = new File("src/main/resources/circuitos/" + arquivoXml);
+        circuito = CarregadorRecursos.carregarCircuito(arquivoXml);
+        testePista = new TestePista(this, circuito);
+        backGround = CarregadorRecursos.carregaBackGround(circuito.getBackGround(), this, circuito);
+        iniciaEditor();
+        atualizaListas();
+        vetorizarCircuito();
+        refletirCircuitoNosCampos();
+        srcFrame.pack();
+        srcFrame.setExtendedState(JFrame.MAXIMIZED_BOTH);
+        if (circuito.getPistaFull() != null && !circuito.getPistaFull().isEmpty()) {
+            centralizarPonto(((No) circuito.getPistaFull().get(0)).getPoint());
+        }
+    }
+
+    private void refletirCircuitoNosCampos() {
+        larguraPistaSpinner.getModel().setValue(Double.valueOf(circuito.getMultiplicadorLarguraPista()));
+        probalidadeChuvaText.setText(String.valueOf(circuito.getProbalidadeChuva()));
+        nomePistaText.setText(circuito.getNome());
+        noite.setSelected(circuito.isNoite());
+        if (ativoCheckBox != null) {
+            ativoCheckBox.setSelected(circuito.isAtivo());
+        }
+        atualizaCorLabel(corFundoLabel, circuito.getCorFundo(), Color.WHITE);
+        atualizaCorLabel(corAsfaltoLabel, circuito.getCorAsfalto(), DesenhoProceduralCircuito.COR_PISTA);
     }
 
     private JPanel gerarListsNosPistaBox() {
@@ -537,7 +860,7 @@ public class MainPanelEditor extends JPanel {
         return controlPanel;
     }
 
-    private void gerarLayout(JFrame frame, JPanel controlPanel, JPanel buttonsPanel, JPanel radiosPanel) {
+    private void gerarLayout(JFrame frame) {
         frame.getContentPane().removeAll();
         frame.setLayout(new BorderLayout());
         if (backGround != null)
@@ -545,24 +868,29 @@ public class MainPanelEditor extends JPanel {
         else {
             this.setPreferredSize(new Dimension(10000, 10000));
         }
-        frame.getContentPane().add(controlPanel, BorderLayout.WEST);
+        JPanel nortePanel = new JPanel(new BorderLayout());
+        nortePanel.add(gerarTopoNavegacaoEAcoes(), BorderLayout.NORTH);
+        nortePanel.add(gerarLinhaVisualizacaoETeste(), BorderLayout.SOUTH);
+        frame.getContentPane().add(nortePanel, BorderLayout.NORTH);
+
+        frame.getContentPane().add(gerarSplitPaneLateral(), BorderLayout.EAST);
+
         scrollPane = new JScrollPane(this, JScrollPane.VERTICAL_SCROLLBAR_NEVER,
                 JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
         frame.getContentPane().add(scrollPane, BorderLayout.CENTER);
-        JPanel nothPanel = new JPanel(new GridLayout(2, 1));
-        nothPanel.add(radiosPanel);
-        nothPanel.add(buttonsPanel);
-        frame.getContentPane().add(nothPanel, BorderLayout.NORTH);
-        frame.getContentPane().add(iniciaEditorVetorizado(), BorderLayout.SOUTH);
-        formularioListaObjetos = new FormularioListaObjetos(this);
-        formularioListaObjetos.listarObjetos();
-        formularioListaObjetosCenario = new FormularioListaObjetos(this, Circuito::getObjetosCenario);
-        formularioListaObjetosCenario.listarObjetos();
-        JPanel listasObjetosPanel = new JPanel(new GridLayout(2, 1));
-        listasObjetosPanel.add(formularioListaObjetos.getObjetos());
-        listasObjetosPanel.add(formularioListaObjetosCenario.getObjetos());
-        frame.getContentPane().add(listasObjetosPanel, BorderLayout.EAST);
+    }
 
+    private JPanel gerarLinhaVisualizacaoETeste() {
+        JPanel linha = new JPanel(new GridLayout(1, 2)) {
+            @Override
+            public Dimension getPreferredSize() {
+                Dimension d = super.getPreferredSize();
+                return new Dimension(d.width, (int) (d.height * 0.7));
+            }
+        };
+        linha.add(gerarBotoesVisualizacao());
+        linha.add(gerarBotoesTestePista());
+        return linha;
     }
 
     public void esquerda() {
@@ -631,6 +959,12 @@ public class MainPanelEditor extends JPanel {
     }
 
     private void adicionaEventosMouse(final JFrame frame) {
+        for (java.awt.event.MouseListener ml : this.getMouseListeners()) {
+            this.removeMouseListener(ml);
+        }
+        for (java.awt.event.MouseMotionListener mml : this.getMouseMotionListeners()) {
+            this.removeMouseMotionListener(mml);
+        }
         MouseAdapter mouseAdapter = new MouseAdapter() {
 
             public void mouseEntered(MouseEvent e) {
@@ -639,7 +973,7 @@ public class MainPanelEditor extends JPanel {
             }
 
             public void mousePressed(MouseEvent e) {
-                if (!semSelecaoButton.isSelected() || !SwingUtilities.isLeftMouseButton(e)
+                if (!isSemSelecao() || !SwingUtilities.isLeftMouseButton(e)
                         || posicionaObjetoPista || desenhandoObjetoLivre) {
                     return;
                 }
@@ -673,7 +1007,7 @@ public class MainPanelEditor extends JPanel {
                     arrastouObjeto = false;
                     return;
                 }
-                if (semSelecaoButton.isSelected()) {
+                if (isSemSelecao()) {
                     clickEditarObjetos(e);
                 } else {
                     No no = new No();
@@ -880,8 +1214,7 @@ public class MainPanelEditor extends JPanel {
     }
 
     private void inserirNoNasJList(No no) {
-        if (boxButton.isSelected() || paraBoxButton.isSelected() || fimBoxButton.isSelected()
-                || boxRetaButton.isSelected() || boxCurvaAltaButton.isSelected()) {
+        if (isTipoNoAtualBox()) {
             DefaultListModel model = ((DefaultListModel) boxJList.getModel());
             if (ultimoItemBoxSelecionado > -1) {
                 ultimoItemBoxSelecionado += 1;
@@ -1589,7 +1922,7 @@ public class MainPanelEditor extends JPanel {
     }
 
     public void creditos() {
-        semSelecaoButton.setSelected(true);
+        desSelecionaNosPista();
         objetoPista = null;
         if (circuito.getCreditos() != null) {
             centralizarPonto(circuito.getCreditos());
@@ -1597,82 +1930,66 @@ public class MainPanelEditor extends JPanel {
         creditos = true;
     }
 
+    private OpcaoTipoNo getOpcaoTipoNo() {
+        return tipoNoCombo != null ? (OpcaoTipoNo) tipoNoCombo.getSelectedItem() : null;
+    }
+
+    private boolean isSemSelecao() {
+        OpcaoTipoNo opcao = getOpcaoTipoNo();
+        return opcao == null || opcao.tipo == null;
+    }
+
+    private boolean isTipoNoAtualBox() {
+        OpcaoTipoNo opcao = getOpcaoTipoNo();
+        return opcao != null && opcao.box;
+    }
+
     public Color getTipoNo() {
-        if (largadaButton.isSelected()) {
-            tipoNo = No.LARGADA;
-        }
-        if (retaButton.isSelected()) {
-            tipoNo = No.RETA;
-        }
-        if (curvaAltaButton.isSelected()) {
-            tipoNo = No.CURVA_ALTA;
-        }
-        if (curvaBaixaButton.isSelected()) {
-            tipoNo = No.CURVA_BAIXA;
-        }
-        if (boxButton.isSelected()) {
-            tipoNo = No.BOX;
-        }
-        if (boxRetaButton.isSelected()) {
-            tipoNo = No.RETA;
-        }
-        if (boxCurvaAltaButton.isSelected()) {
-            tipoNo = No.CURVA_ALTA;
-        }
-        if (paraBoxButton.isSelected()) {
-            tipoNo = No.PARADA_BOX;
-        }
-        if (fimBoxButton.isSelected()) {
-            tipoNo = No.FIM_BOX;
-        }
+        OpcaoTipoNo opcao = getOpcaoTipoNo();
+        tipoNo = opcao != null ? opcao.tipo : null;
         return tipoNo;
     }
 
-    private JPanel iniciaEditorVetorizado() {
-        JPanel radioPistaPanel = new JPanel();
-        radioPistaPanel.add(new JLabel("Nos da Pista"));
-        JPanel radioBoxPanel = new JPanel();
-        radioBoxPanel.add(new JLabel("Nos do Box"));
-        JPanel buttonsPanel = new JPanel();
-        buttonsPanel.setLayout(new GridLayout(2, 1));
-
+    private JPanel gerarBotoesTestePista() {
         JPanel buttonsPanel1 = new JPanel();
         buttonsPanel1.setLayout(new GridLayout(1, 6));
 
-        JButton testaPistaButton = new JButton("Iniciar/Parar Teste de Pista");
-        testaPistaButton.addActionListener(new ActionListener() {
+        JCheckBox testaPistaCheck = new JCheckBox("Teste Pista");
+        testaPistaCheck.setSelected(testePista != null && testePista.isAlive());
+        testaPistaCheck.addActionListener(new ActionListener() {
             public void actionPerformed(ActionEvent e) {
                 try {
-                    if (testePista.isAlive()) {
-                        testePista.pararTeste();
-                    } else {
+                    if (testaPistaCheck.isSelected()) {
                         vetorizarCircuito();
                         testePista.iniciarTeste(multiplicadorPista);
+                    } else {
+                        testePista.pararTeste();
                     }
-
                 } catch (Exception e1) {
                     e1.printStackTrace();
                     srcFrame.dialogDeErro(e1);
                 }
             }
         });
-        buttonsPanel1.add(testaPistaButton);
+        buttonsPanel1.add(testaPistaCheck);
 
-        JButton testaBoxButton = new JButton("Ligar/Desligar Box");
-        testaBoxButton.addActionListener(new ActionListener() {
+        JCheckBox testaBoxCheck = new JCheckBox("Box");
+        testaBoxCheck.setSelected(testePista != null && testePista.isIrProBox());
+        testaBoxCheck.addActionListener(new ActionListener() {
             public void actionPerformed(ActionEvent e) {
                 testePista.testarBox();
             }
         });
-        buttonsPanel1.add(testaBoxButton);
+        buttonsPanel1.add(testaBoxCheck);
 
-        JButton testaEscapadaButton = new JButton("Ligar/Desligar Modo Escapada");
-        testaEscapadaButton.addActionListener(new ActionListener() {
+        JCheckBox testaEscapadaCheck = new JCheckBox("Escapada");
+        testaEscapadaCheck.setSelected(testePista != null && testePista.isModoEscapada());
+        testaEscapadaCheck.addActionListener(new ActionListener() {
             public void actionPerformed(ActionEvent e) {
                 testePista.testarEscapada();
             }
         });
-        buttonsPanel1.add(testaEscapadaButton);
+        buttonsPanel1.add(testaEscapadaCheck);
 
         JButton left = new JButton() {
             @Override
@@ -1713,144 +2030,7 @@ public class MainPanelEditor extends JPanel {
             }
         });
         buttonsPanel1.add(right);
-
-        JPanel buttonsPanel2 = new JPanel();
-        buttonsPanel2.setLayout(new GridLayout());
-
-        nomePistaText = new JTextField() {
-            @Override
-            public Dimension getPreferredSize() {
-                return new Dimension(150, 40);
-            }
-        };
-        if (circuito != null) {
-            nomePistaText.setText(circuito.getNome());
-        }
-        buttonsPanel2.add(new JLabel("Nome do circuito"));
-        buttonsPanel2.add(nomePistaText);
-
-        ladoBoxCombo = new JComboBox();
-        ladoBoxCombo.addItem(LADO_COMBO_1);
-        ladoBoxCombo.addItem(LADO_COMBO_2);
-        if (circuito != null && circuito.getLadoBox() == 2) {
-            ladoBoxCombo.setSelectedItem(LADO_COMBO_2);
-        }
-        buttonsPanel2.add(ladoBoxCombo);
-
-        ladoBoxSaidaBoxCombo = new JComboBox();
-        ladoBoxSaidaBoxCombo.addItem(SAIDA_LADO_COMBO_1);
-        ladoBoxSaidaBoxCombo.addItem(SAIDA_LADO_COMBO_2);
-        if (circuito != null && circuito.getLadoBoxSaidaBox() == 2) {
-            ladoBoxSaidaBoxCombo.setSelectedItem(SAIDA_LADO_COMBO_2);
-        }
-        buttonsPanel2.add(ladoBoxSaidaBoxCombo);
-
-        probalidadeChuvaText = new JTextField() {
-            @Override
-            public Dimension getPreferredSize() {
-                return new Dimension(30, super.getPreferredSize().height);
-            }
-        };
-        if (circuito != null) {
-            probalidadeChuvaText.setText("" + circuito.getProbalidadeChuva());
-        }
-        JPanel p2 = new JPanel();
-        p2.add(new JLabel() {
-            @Override
-            public String getText() {
-                return "% Chuva";
-            }
-        });
-        p2.add(probalidadeChuvaText);
-        buttonsPanel2.add(p2);
-
-        if (multiplicadorLarguraPista < 1.0) {
-            multiplicadorLarguraPista = 1.0;
-        }
-        if (multiplicadorLarguraPista > 2.0) {
-            multiplicadorLarguraPista = 2.0;
-        }
-        SpinnerNumberModel model1 = new SpinnerNumberModel(multiplicadorLarguraPista, 1.0, 2.0, 0.1);
-        larguraPistaSpinner = new JSpinner(model1) {
-            @Override
-            public Dimension getPreferredSize() {
-                return new Dimension(60, super.getPreferredSize().height);
-            }
-        };
-        larguraPistaSpinner.addChangeListener(new ChangeListener() {
-            @Override
-            public void stateChanged(ChangeEvent e) {
-                circuito.setMultiplicadorLarguraPista(((Double) larguraPistaSpinner.getModel().getValue()).doubleValue());
-                vetorizarCircuito();
-                repaint();
-            }
-        });
-        p2 = new JPanel();
-        p2.add(new JLabel() {
-            @Override
-            public String getText() {
-                return "Largura";
-            }
-        });
-        p2.add(larguraPistaSpinner);
-        buttonsPanel2.add(p2);
-
-        p2 = new JPanel();
-        p2.add(new JLabel("Noite") {
-            @Override
-            public String getText() {
-                return "Noite";
-            }
-        });
-
-        noite.addChangeListener(new ChangeListener() {
-            @Override
-            public void stateChanged(ChangeEvent e) {
-                circuito.setNoite(noite.isSelected());
-                repaint();
-            }
-        });
-        p2.add(noite);
-        buttonsPanel2.add(p2);
-
-        p2 = new JPanel();
-        p2.add(new JLabel("Cor de Fundo"));
-        atualizaCorLabel(corFundoLabel, circuito != null ? circuito.getCorFundo() : null, Color.WHITE);
-        corFundoLabel.addMouseListener(new MouseAdapter() {
-            public void mouseClicked(MouseEvent e) {
-                Color nova = JColorChooser.showDialog(MainPanelEditor.this,
-                        "Cor de Fundo", corFundoLabel.getBackground());
-                if (nova != null) {
-                    circuito.setCorFundo(nova);
-                    atualizaCorLabel(corFundoLabel, nova, Color.WHITE);
-                    repaint();
-                }
-            }
-        });
-        p2.add(corFundoLabel);
-        buttonsPanel2.add(p2);
-
-        p2 = new JPanel();
-        p2.add(new JLabel("Cor do Asfalto"));
-        atualizaCorLabel(corAsfaltoLabel, circuito != null ? circuito.getCorAsfalto() : null,
-                DesenhoProceduralCircuito.COR_PISTA);
-        corAsfaltoLabel.addMouseListener(new MouseAdapter() {
-            public void mouseClicked(MouseEvent e) {
-                Color nova = JColorChooser.showDialog(MainPanelEditor.this,
-                        "Cor do Asfalto", corAsfaltoLabel.getBackground());
-                if (nova != null) {
-                    circuito.setCorAsfalto(nova);
-                    atualizaCorLabel(corAsfaltoLabel, nova, DesenhoProceduralCircuito.COR_PISTA);
-                    repaint();
-                }
-            }
-        });
-        p2.add(corAsfaltoLabel);
-        buttonsPanel2.add(p2);
-
-        buttonsPanel.add(buttonsPanel1);
-        buttonsPanel.add(buttonsPanel2);
-        return buttonsPanel;
+        return buttonsPanel1;
     }
 
     public void centralizarPonto(Point pin) {
@@ -2063,7 +2243,9 @@ public class MainPanelEditor extends JPanel {
     }
 
     public void desSelecionaNosPista() {
-        semSelecaoButton.setSelected(true);
+        if (tipoNoCombo != null) {
+            tipoNoCombo.setSelectedIndex(0);
+        }
     }
 
 
@@ -2076,51 +2258,26 @@ public class MainPanelEditor extends JPanel {
         if (result == JFileChooser.CANCEL_OPTION) {
             return;
         }
-        File file = fileChooser.getSelectedFile();
-        backGround = CarregadorRecursos.carregaBackGround(file.getName(), this, circuito);
-        if (backGround == null) {
+        File imagemFile = fileChooser.getSelectedFile();
+        Circuito novoCircuito = new Circuito();
+        BufferedImage novoBackGround = CarregadorRecursos.carregaBackGround(imagemFile.getName(), this, novoCircuito);
+        if (novoBackGround == null) {
             JOptionPane.showMessageDialog(null,
                     "Imagem para criar circuito deve esta na pasta /f1mane/src/sowbreira/f1mane/recursos/",
                     "Operação ilegal", JOptionPane.ERROR_MESSAGE);
             return;
         }
-        circuito.setBackGround(file.getName());
+        file = null;
+        indiceCircuito = -1;
+        circuito = novoCircuito;
+        backGround = novoBackGround;
+        circuito.setBackGround(imagemFile.getName());
         testePista = new TestePista(this, circuito);
         iniciaEditor();
         atualizaListas();
+        refletirCircuitoNosCampos();
+        lblCircuitoAtual.setText("(novo circuito, não salvo)");
         srcFrame.pack();
         srcFrame.setExtendedState(JFrame.MAXIMIZED_BOTH);
-    }
-
-    public void editar() throws IOException, ClassNotFoundException {
-        JFileChooser fileChooser = new JFileChooser(new File("src/main/resources/circuitos"));
-        fileChooser.setFileSelectionMode(JFileChooser.FILES_ONLY);
-
-        ExampleFileFilter exampleFileFilter = new ExampleFileFilter("xml");
-        fileChooser.setFileFilter(exampleFileFilter);
-
-        int result = fileChooser.showOpenDialog(null);
-
-        if (result == JFileChooser.CANCEL_OPTION) {
-            return;
-        }
-        file = fileChooser.getSelectedFile();
-        circuito = CarregadorRecursos.carregarCircuito(fileChooser.getSelectedFile().getName());
-        testePista = new TestePista(this, circuito);
-        backGround = CarregadorRecursos.carregaBackGround(circuito.getBackGround(), this, circuito);
-        iniciaEditor();
-        atualizaListas();
-        vetorizarCircuito();
-        larguraPistaSpinner.getModel().setValue(Double.valueOf(circuito.getMultiplicadorLarguraPista()));
-        probalidadeChuvaText.setText(String.valueOf(circuito.getProbalidadeChuva()));
-        nomePistaText.setText(circuito.getNome());
-        noite.setSelected(circuito.isNoite());
-        atualizaCorLabel(corFundoLabel, circuito.getCorFundo(), Color.WHITE);
-        atualizaCorLabel(corAsfaltoLabel, circuito.getCorAsfalto(), DesenhoProceduralCircuito.COR_PISTA);
-        srcFrame.pack();
-        srcFrame.setExtendedState(JFrame.MAXIMIZED_BOTH);
-        if (circuito.getPistaFull() != null && !circuito.getPistaFull().isEmpty()) {
-            centralizarPonto(((No) circuito.getPistaFull().get(0)).getPoint());
-        }
     }
 }

--- a/src/main/java/br/f1mane/entidades/Circuito.java
+++ b/src/main/java/br/f1mane/entidades/Circuito.java
@@ -52,6 +52,7 @@ public class Circuito implements Serializable {
     private String nome;
     private boolean noite;
     private boolean usaBkg;
+    private boolean ativo;
     private transient List<ObjetoPistaJSon> objetosNoTransparencia;
 
     @JsonIgnore
@@ -649,6 +650,14 @@ public class Circuito implements Serializable {
 
     public void setNoite(boolean noite) {
         this.noite = noite;
+    }
+
+    public boolean isAtivo() {
+        return ativo;
+    }
+
+    public void setAtivo(boolean ativo) {
+        this.ativo = ativo;
     }
 
     public List<Point> getEscapeList() {

--- a/src/main/resources/circuitos/albert_park_mro.xml
+++ b/src/main/resources/circuitos/albert_park_mro.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <java version="23.0.1" class="java.beans.XMLDecoder">
  <object class="br.f1mane.entidades.Circuito" id="Circuito0">
+  <void property="ativo">
+   <boolean>true</boolean>
+  </void>
   <void property="backGround">
    <string>albert_park_mro.jpg</string>
   </void>

--- a/src/main/resources/circuitos/austin_mro.xml
+++ b/src/main/resources/circuitos/austin_mro.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <java version="11.0.24" class="java.beans.XMLDecoder">
  <object class="br.f1mane.entidades.Circuito" id="Circuito0">
+  <void property="ativo">
+   <boolean>true</boolean>
+  </void>
   <void property="backGround">
    <string>austin_mro.jpg</string>
   </void>

--- a/src/main/resources/circuitos/bahrain_mro.xml
+++ b/src/main/resources/circuitos/bahrain_mro.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <java version="11.0.20.1" class="java.beans.XMLDecoder">
  <object class="br.f1mane.entidades.Circuito" id="Circuito0">
+  <void property="ativo">
+   <boolean>true</boolean>
+  </void>
   <void property="backGround">
    <string>bahrain_mro.jpg</string>
   </void>

--- a/src/main/resources/circuitos/baku_mro.xml
+++ b/src/main/resources/circuitos/baku_mro.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <java version="11.0.23" class="java.beans.XMLDecoder">
  <object class="br.f1mane.entidades.Circuito" id="Circuito0">
+  <void property="ativo">
+   <boolean>true</boolean>
+  </void>
   <void property="backGround">
    <string>baku_mro.jpg</string>
   </void>

--- a/src/main/resources/circuitos/donington_mro.xml
+++ b/src/main/resources/circuitos/donington_mro.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <java version="11.0.24" class="java.beans.XMLDecoder">
  <object class="br.f1mane.entidades.Circuito" id="Circuito0">
+  <void property="ativo">
+   <boolean>true</boolean>
+  </void>
   <void property="backGround">
    <string>donington_mro.jpg</string>
   </void>

--- a/src/main/resources/circuitos/estoril_mro.xml
+++ b/src/main/resources/circuitos/estoril_mro.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <java version="11.0.24" class="java.beans.XMLDecoder">
  <object class="br.f1mane.entidades.Circuito" id="Circuito0">
+  <void property="ativo">
+   <boolean>true</boolean>
+  </void>
   <void property="backGround">
    <string>estoril_mro.jpg</string>
   </void>

--- a/src/main/resources/circuitos/fuji_mro.xml
+++ b/src/main/resources/circuitos/fuji_mro.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <java version="11.0.24" class="java.beans.XMLDecoder">
  <object class="br.f1mane.entidades.Circuito" id="Circuito0">
+  <void property="ativo">
+   <boolean>true</boolean>
+  </void>
   <void property="backGround">
    <string>fuji_mro.jpg</string>
   </void>

--- a/src/main/resources/circuitos/hockenheim6601_mro.xml
+++ b/src/main/resources/circuitos/hockenheim6601_mro.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <java version="11.0.24" class="java.beans.XMLDecoder">
  <object class="br.f1mane.entidades.Circuito" id="Circuito0">
+  <void property="ativo">
+   <boolean>true</boolean>
+  </void>
   <void property="backGround">
    <string>hockenheim6601_mro.jpg</string>
   </void>

--- a/src/main/resources/circuitos/hockenheim_mro.xml
+++ b/src/main/resources/circuitos/hockenheim_mro.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <java version="11.0.23" class="java.beans.XMLDecoder">
  <object class="br.f1mane.entidades.Circuito" id="Circuito0">
+  <void property="ativo">
+   <boolean>true</boolean>
+  </void>
   <void property="backGround">
    <string>hockenheim_mro.jpg</string>
   </void>

--- a/src/main/resources/circuitos/hungaro_ring_mro.xml
+++ b/src/main/resources/circuitos/hungaro_ring_mro.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <java version="11.0.24" class="java.beans.XMLDecoder">
  <object class="br.f1mane.entidades.Circuito" id="Circuito0">
+  <void property="ativo">
+   <boolean>true</boolean>
+  </void>
   <void property="backGround">
    <string>hungaro_ring_mro.jpg</string>
   </void>

--- a/src/main/resources/circuitos/imola_mro.xml
+++ b/src/main/resources/circuitos/imola_mro.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <java version="11.0.24" class="java.beans.XMLDecoder">
  <object class="br.f1mane.entidades.Circuito" id="Circuito0">
+  <void property="ativo">
+   <boolean>true</boolean>
+  </void>
   <void property="backGround">
    <string>imola_mro.jpg</string>
   </void>

--- a/src/main/resources/circuitos/india_mro.xml
+++ b/src/main/resources/circuitos/india_mro.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <java version="11.0.20.1" class="java.beans.XMLDecoder">
  <object class="br.f1mane.entidades.Circuito" id="Circuito0">
+  <void property="ativo">
+   <boolean>true</boolean>
+  </void>
   <void property="backGround">
    <string>india_mro.jpg</string>
   </void>

--- a/src/main/resources/circuitos/indianapoles_mro.xml
+++ b/src/main/resources/circuitos/indianapoles_mro.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <java version="11.0.24" class="java.beans.XMLDecoder">
  <object class="br.f1mane.entidades.Circuito" id="Circuito0">
+  <void property="ativo">
+   <boolean>true</boolean>
+  </void>
   <void property="backGround">
    <string>indianapolis_mro.jpg</string>
   </void>

--- a/src/main/resources/circuitos/interlagos_mro.xml
+++ b/src/main/resources/circuitos/interlagos_mro.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <java version="11.0.25" class="java.beans.XMLDecoder">
  <object class="br.f1mane.entidades.Circuito" id="Circuito0">
+  <void property="ativo">
+   <boolean>true</boolean>
+  </void>
   <void property="backGround">
    <string>interlagos_mro.jpg</string>
   </void>

--- a/src/main/resources/circuitos/istambul_mro.xml
+++ b/src/main/resources/circuitos/istambul_mro.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <java version="11.0.24" class="java.beans.XMLDecoder">
  <object class="br.f1mane.entidades.Circuito" id="Circuito0">
+  <void property="ativo">
+   <boolean>true</boolean>
+  </void>
   <void property="backGround">
    <string>istambul_mro.jpg</string>
   </void>

--- a/src/main/resources/circuitos/jacarepagua_mro.xml
+++ b/src/main/resources/circuitos/jacarepagua_mro.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <java version="11.0.20.1" class="java.beans.XMLDecoder">
  <object class="br.f1mane.entidades.Circuito" id="Circuito0">
+  <void property="ativo">
+   <boolean>true</boolean>
+  </void>
   <void property="backGround">
    <string>jacarepagua_mro.jpg</string>
   </void>

--- a/src/main/resources/circuitos/jeddah_mro.xml
+++ b/src/main/resources/circuitos/jeddah_mro.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <java version="11.0.23" class="java.beans.XMLDecoder">
  <object class="br.f1mane.entidades.Circuito" id="Circuito0">
+  <void property="ativo">
+   <boolean>true</boolean>
+  </void>
   <void property="backGround">
    <string>jeddah_mro.jpg</string>
   </void>

--- a/src/main/resources/circuitos/jerez_mro.xml
+++ b/src/main/resources/circuitos/jerez_mro.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <java version="11.0.20.1" class="java.beans.XMLDecoder">
  <object class="br.f1mane.entidades.Circuito" id="Circuito0">
+  <void property="ativo">
+   <boolean>true</boolean>
+  </void>
   <void property="backGround">
    <string>jerez_mro.jpg</string>
   </void>

--- a/src/main/resources/circuitos/magny_mro.xml
+++ b/src/main/resources/circuitos/magny_mro.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <java version="11.0.24" class="java.beans.XMLDecoder">
  <object class="br.f1mane.entidades.Circuito" id="Circuito0">
+  <void property="ativo">
+   <boolean>true</boolean>
+  </void>
   <void property="backGround">
    <string>magny_mro.jpg</string>
   </void>

--- a/src/main/resources/circuitos/mexico_mro.xml
+++ b/src/main/resources/circuitos/mexico_mro.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <java version="11.0.20.1" class="java.beans.XMLDecoder">
  <object class="br.f1mane.entidades.Circuito" id="Circuito0">
+  <void property="ativo">
+   <boolean>true</boolean>
+  </void>
   <void property="backGround">
    <string>mexico_mro.jpg</string>
   </void>

--- a/src/main/resources/circuitos/montecarlo_mro.xml
+++ b/src/main/resources/circuitos/montecarlo_mro.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <java version="11.0.20.1" class="java.beans.XMLDecoder">
  <object class="br.f1mane.entidades.Circuito" id="Circuito0">
+  <void property="ativo">
+   <boolean>true</boolean>
+  </void>
   <void property="backGround">
    <string>montecarlo_mro.jpg</string>
   </void>

--- a/src/main/resources/circuitos/montreal_mro.xml
+++ b/src/main/resources/circuitos/montreal_mro.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <java version="11.0.20.1" class="java.beans.XMLDecoder">
  <object class="br.f1mane.entidades.Circuito" id="Circuito0">
+  <void property="ativo">
+   <boolean>true</boolean>
+  </void>
   <void property="backGround">
    <string>montreal_mro.jpg</string>
   </void>

--- a/src/main/resources/circuitos/monza_mro.xml
+++ b/src/main/resources/circuitos/monza_mro.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <java version="11.0.24" class="java.beans.XMLDecoder">
  <object class="br.f1mane.entidades.Circuito" id="Circuito0">
+  <void property="ativo">
+   <boolean>true</boolean>
+  </void>
   <void property="backGround">
    <string>monza_mro.jpg</string>
   </void>

--- a/src/main/resources/circuitos/nuburgring_mro.xml
+++ b/src/main/resources/circuitos/nuburgring_mro.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <java version="11.0.20.1" class="java.beans.XMLDecoder">
  <object class="br.f1mane.entidades.Circuito" id="Circuito0">
+  <void property="ativo">
+   <boolean>true</boolean>
+  </void>
   <void property="backGround">
    <string>nuburgring_mro.jpg</string>
   </void>

--- a/src/main/resources/circuitos/osterreichring_mro.xml
+++ b/src/main/resources/circuitos/osterreichring_mro.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <java version="11.0.20.1" class="java.beans.XMLDecoder">
  <object class="br.f1mane.entidades.Circuito" id="Circuito0">
+  <void property="ativo">
+   <boolean>true</boolean>
+  </void>
   <void property="backGround">
    <string>osterreichring_mro.jpg</string>
   </void>

--- a/src/main/resources/circuitos/paulricard_mro.xml
+++ b/src/main/resources/circuitos/paulricard_mro.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <java version="11.0.24" class="java.beans.XMLDecoder">
  <object class="br.f1mane.entidades.Circuito" id="Circuito0">
+  <void property="ativo">
+   <boolean>true</boolean>
+  </void>
   <void property="backGround">
    <string>paulricard_mro.jpg</string>
   </void>

--- a/src/main/resources/circuitos/phoenix_mro.xml
+++ b/src/main/resources/circuitos/phoenix_mro.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <java version="11.0.20.1" class="java.beans.XMLDecoder">
  <object class="br.f1mane.entidades.Circuito" id="Circuito0">
+  <void property="ativo">
+   <boolean>true</boolean>
+  </void>
   <void property="backGround">
    <string>phoenix_mro.jpg</string>
   </void>

--- a/src/main/resources/circuitos/shangai_mro.xml
+++ b/src/main/resources/circuitos/shangai_mro.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <java version="11.0.20.1" class="java.beans.XMLDecoder">
  <object class="br.f1mane.entidades.Circuito" id="Circuito0">
+  <void property="ativo">
+   <boolean>true</boolean>
+  </void>
   <void property="backGround">
    <string>shangai_mro.jpg</string>
   </void>

--- a/src/main/resources/circuitos/silverstone_mro.xml
+++ b/src/main/resources/circuitos/silverstone_mro.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <java version="11.0.20.1" class="java.beans.XMLDecoder">
  <object class="br.f1mane.entidades.Circuito" id="Circuito0">
+  <void property="ativo">
+   <boolean>true</boolean>
+  </void>
   <void property="backGround">
    <string>silverstone_mro.jpg</string>
   </void>

--- a/src/main/resources/circuitos/singapura_mro.xml
+++ b/src/main/resources/circuitos/singapura_mro.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <java version="11.0.20.1" class="java.beans.XMLDecoder">
  <object class="br.f1mane.entidades.Circuito" id="Circuito0">
+  <void property="ativo">
+   <boolean>true</boolean>
+  </void>
   <void property="backGround">
    <string>singapura_mro.jpg</string>
   </void>

--- a/src/main/resources/circuitos/spa_mro.xml
+++ b/src/main/resources/circuitos/spa_mro.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <java version="11.0.20.1" class="java.beans.XMLDecoder">
  <object class="br.f1mane.entidades.Circuito" id="Circuito0">
+  <void property="ativo">
+   <boolean>true</boolean>
+  </void>
   <void property="backGround">
    <string>spa_mro.jpg</string>
   </void>

--- a/src/main/resources/circuitos/spang_mro.xml
+++ b/src/main/resources/circuitos/spang_mro.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <java version="11.0.20.1" class="java.beans.XMLDecoder">
  <object class="br.f1mane.entidades.Circuito" id="Circuito0">
+  <void property="ativo">
+   <boolean>true</boolean>
+  </void>
   <void property="backGround">
    <string>spang_mro.jpg</string>
   </void>

--- a/src/main/resources/circuitos/suzuka_mro.xml
+++ b/src/main/resources/circuitos/suzuka_mro.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <java version="11.0.24" class="java.beans.XMLDecoder">
  <object class="br.f1mane.entidades.Circuito" id="Circuito0">
+  <void property="ativo">
+   <boolean>true</boolean>
+  </void>
   <void property="backGround">
    <string>suzuka_mro.jpg</string>
   </void>

--- a/src/main/resources/circuitos/valencia_mro.xml
+++ b/src/main/resources/circuitos/valencia_mro.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <java version="11.0.20.1" class="java.beans.XMLDecoder">
  <object class="br.f1mane.entidades.Circuito" id="Circuito0">
+  <void property="ativo">
+   <boolean>true</boolean>
+  </void>
   <void property="backGround">
    <string>valencia_mro.jpg</string>
   </void>

--- a/src/main/resources/circuitos/yas_marina_mro.xml
+++ b/src/main/resources/circuitos/yas_marina_mro.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <java version="11.0.24" class="java.beans.XMLDecoder">
  <object class="br.f1mane.entidades.Circuito" id="Circuito0">
+  <void property="ativo">
+   <boolean>true</boolean>
+  </void>
   <void property="backGround">
    <string>yas_marina_mro.jpg</string>
   </void>


### PR DESCRIPTION
Substitui a navegacao por JFileChooser do editor de circuitos por Anterior/Proximo sobre circuitos.properties (mesmo padrao de EditorCoresCarros), consolida listas e acoes de nos/objetos em um split pane lateral, remove o menu em favor de botoes (Salvar/Nova) e converte toggles (tracado, background, teste de pista, box, escapada) em checkboxes.

Adiciona a propriedade `ativo` (default false) a Circuito, filtrada em ControleRecursos.carregarCircuitos() para esconder circuitos inativos dos seletores em jogo; migra os 37 circuitos existentes para ativo=true para preservar o comportamento atual.