### PR TITLE
fix: impede overlap de carros e melhora mudancas de tracado

### DIFF
--- a/src/main/java/br/f1mane/controles/ControleJogoLocal.java
+++ b/src/main/java/br/f1mane/controles/ControleJogoLocal.java
@@ -189,12 +189,69 @@ public class ControleJogoLocal extends ControleRecursos
      */
     public void atualizaIndexTracadoPilotos() {
         decrementaTracado();
+        if (br.nnpe.Global.LOG_COLISAO) {
+            logSobreposicaoReal();
+        }
     }
 
     public void decrementaTracado() {
         for (Iterator iterator = pilotos.iterator(); iterator.hasNext(); ) {
             Piloto piloto = (Piloto) iterator.next();
             piloto.decIndiceTracado();
+        }
+    }
+
+    /**
+     * Loga pares de carros sobrepostos na posicao real (mesma linha visual e
+     * distancia menor que um carro) para analise dos cenarios de overlap.
+     */
+    private void logSobreposicaoReal() {
+        List<No> pista = getNosDaPista();
+        if (pista == null || pista.isEmpty() || pilotos == null) {
+            return;
+        }
+        int n = pista.size();
+        int limite = Piloto.METADE_CARRO * 2;
+        for (int i = 0; i < pilotos.size(); i++) {
+            Piloto a = pilotos.get(i);
+            if (a == null || a.getNoAtual() == null || a.getNoAtual().isBox() || a.getPtosBox() != 0
+                    || a.verificaNaoPrecisaDesenhar() || verificaNoPitLane(a)) {
+                continue;
+            }
+            for (int j = i + 1; j < pilotos.size(); j++) {
+                Piloto b = pilotos.get(j);
+                if (b == null || b.getNoAtual() == null || b.getNoAtual().isBox() || b.getPtosBox() != 0
+                        || b.verificaNaoPrecisaDesenhar() || verificaNoPitLane(b)) {
+                    continue;
+                }
+                boolean mesmaLinha = a.getTracado() == b.getTracado()
+                        || (a.getIndiceTracado() > 0 && a.getTracadoAntigo() == b.getTracado())
+                        || (b.getIndiceTracado() > 0 && b.getTracadoAntigo() == a.getTracado());
+                if (!mesmaLinha) {
+                    continue;
+                }
+                int d = b.getNoAtual().getIndex() - a.getNoAtual().getIndex();
+                if (d > n / 2) {
+                    d -= n;
+                }
+                if (d < -n / 2) {
+                    d += n;
+                }
+                if (Math.abs(d) >= limite) {
+                    continue;
+                }
+                Logger.logar("[OVERLAP_REAL] gap=" + d
+                        + " a=" + a.getNome() + " idxA=" + a.getNoAtual().getIndex() + " trcA=" + a.getTracado()
+                        + " antA=" + a.getTracadoAntigo() + " indA=" + a.getIndiceTracado()
+                        + " ganhoA=" + Util.inteiro(a.getGanho()) + " posA=" + a.getPosicao()
+                        + " voltaA=" + a.getNumeroVolta()
+                        + " colA=" + (a.getColisao() != null ? a.getColisao().getNome() : "-")
+                        + " | b=" + b.getNome() + " idxB=" + b.getNoAtual().getIndex() + " trcB=" + b.getTracado()
+                        + " antB=" + b.getTracadoAntigo() + " indB=" + b.getIndiceTracado()
+                        + " ganhoB=" + Util.inteiro(b.getGanho()) + " posB=" + b.getPosicao()
+                        + " voltaB=" + b.getNumeroVolta()
+                        + " colB=" + (b.getColisao() != null ? b.getColisao().getNome() : "-"));
+            }
         }
     }
 

--- a/src/main/java/br/f1mane/entidades/Piloto.java
+++ b/src/main/java/br/f1mane/entidades/Piloto.java
@@ -198,6 +198,8 @@ public class Piloto implements Serializable, PilotoSuave {
     @JsonIgnore
     private boolean colisaoCentro;
     @JsonIgnore
+    private int ciclosPresoFila;
+    @JsonIgnore
     private double limiteEvitarBatrCarroFrente;
     @JsonIgnore
     private boolean evitaBaterCarroFrente;
@@ -312,6 +314,10 @@ public class Piloto implements Serializable, PilotoSuave {
 
     public double getGanho() {
         return ganho;
+    }
+
+    public void setGanho(double ganho) {
+        this.ganho = ganho;
     }
 
     public List getGanhosBaixa() {
@@ -1101,8 +1107,9 @@ public class Piloto implements Serializable, PilotoSuave {
             if (noAtual.verificaCurvaBaixa()) {
                 novoModificador = 10;
             }
-            index += novoModificador;
-            setPtosPista(Util.inteiro(novoModificador + getPtosPista()));
+            long avancoBandeirada = limitaAvancoCarroFrente(Math.round(novoModificador));
+            index += avancoBandeirada;
+            setPtosPista(Util.inteiro(avancoBandeirada + getPtosPista()));
             setVelocidade(controleJogo.getRandom().intervalo(50, 65));
             if (carroPilotoDaFrenteRetardatario != null
                     && getTracado() == carroPilotoDaFrenteRetardatario.getPiloto().getTracado()) {
@@ -1141,8 +1148,12 @@ public class Piloto implements Serializable, PilotoSuave {
         processaSegundosParaRival();
         controleJogo.verificaAcidente(this);
         long roundGanho = Math.round(ganho);
-        setPtosPista(Util.inteiro(getPtosPista() + roundGanho));
-        index += roundGanho;
+        long avancoLimitado = limitaAvancoCarroFrente(roundGanho);
+        if (avancoLimitado < roundGanho) {
+            ganho = avancoLimitado;
+        }
+        setPtosPista(Util.inteiro(getPtosPista() + avancoLimitado));
+        index += avancoLimitado;
         setVelocidade(calculoVelocidade(ganho));
         return index;
     }
@@ -1370,6 +1381,7 @@ public class Piloto implements Serializable, PilotoSuave {
 
     public void processaPenalidadeColisao() {
         if (getColisao() == null) {
+            ciclosPresoFila = 0;
             return;
         }
         incStress(1);
@@ -1378,7 +1390,14 @@ public class Piloto implements Serializable, PilotoSuave {
         }
         Piloto pilotoFrente = getColisao();
         pilotoFrente.setCiclosDesconcentrado(0);
-        if (pilotoFrente.getTracado() == this.tracado) {
+        /**
+         * Considera tambem o carro da frente que ainda esta cruzando esta
+         * linha (mudou de tracado mas o corpo ainda nao saiu dela); antes a
+         * penalidade exigia tracado identico e o carro de tras atravessava.
+         */
+        boolean mesmaLinha = pilotoFrente.getTracado() == this.tracado
+                || (pilotoFrente.getIndiceTracado() > 0 && pilotoFrente.getTracadoAntigo() == this.tracado);
+        if (mesmaLinha) {
             double ganhoFrente = pilotoFrente.getGanho();
             if (colisaoDiantera && getCentroColisao().intersects(pilotoFrente.getCentroColisao())) {
                 ganho = Math.min(ganho, ganhoFrente);
@@ -1388,6 +1407,161 @@ public class Piloto implements Serializable, PilotoSuave {
                 ganho = Math.min(ganho, ganhoFrente);
             }
         }
+        if (mesmaLinha && ganho <= 10) {
+            ciclosPresoFila++;
+        } else {
+            ciclosPresoFila = 0;
+        }
+    }
+
+    /**
+     * Escapa da fila indiana: preso ha varios ciclos atras de um carro lento
+     * na mesma linha, muda para um tracado lateral comprovadamente livre. A
+     * verificacao padrao de mudanca de tracado bloqueia quando qualquer carro
+     * fora do tracado alvo esta a 75 nos - numa fila os proprios vizinhos
+     * impedem a saida mesmo com o tracado do lado totalmente vazio.
+     */
+    boolean tentarEscaparFilaIndiana() {
+        if (ciclosPresoFila < 8) {
+            return false;
+        }
+        if (controleJogo.isSafetyCarNaPista() || isRecebeuBanderada() || verificaDesconcentrado()) {
+            return false;
+        }
+        if (getPtosBox() != 0 || isBox()) {
+            return false;
+        }
+        int tracadoAtual = getTracado();
+        if (tracadoAtual != 0 && tracadoAtual != 1 && tracadoAtual != 2) {
+            return false;
+        }
+        int[] alvos;
+        if (tracadoAtual == 0) {
+            int primeiro = controleJogo.getRandom().intervalo(1, 2);
+            alvos = new int[] { primeiro, primeiro == 1 ? 2 : 1 };
+        } else {
+            alvos = new int[] { 0 };
+        }
+        for (int i = 0; i < alvos.length; i++) {
+            if (verificaTracadoLivreParaEscapar(alvos[i]) && mudarTracado(alvos[i], false, true)) {
+                ciclosPresoFila = 0;
+                if (Global.LOG_COLISAO) {
+                    Logger.logar("[ESCAPE_FILA] piloto=" + getNome() + " de=" + tracadoAtual + " para=" + alvos[i]
+                            + " idx=" + (getNoAtual() != null ? getNoAtual().getIndex() : -1)
+                            + " volta=" + getNumeroVolta());
+                }
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Livre = nenhum carro ocupando ou cruzando o tracado alvo numa janela de
+     * 100 nos atras (nao fechar quem vem rapido) e 60 nos a frente.
+     */
+    public boolean verificaTracadoLivreParaEscapar(int alvo) {
+        No no = getNoAtual();
+        if (no == null || no.isBox()) {
+            return false;
+        }
+        List<No> pista = controleJogo.getNosDaPista();
+        if (pista == null || pista.isEmpty()) {
+            return false;
+        }
+        int n = pista.size();
+        int meuIndex = no.getIndex();
+        List<Piloto> pilotos = controleJogo.getPilotos();
+        for (int i = 0; i < pilotos.size(); i++) {
+            Piloto outro = pilotos.get(i);
+            if (outro == null || outro.equals(this) || verificaNaoPrecisaDesviar(outro)) {
+                continue;
+            }
+            No noOutro = outro.getNoAtual();
+            if (noOutro == null || noOutro.isBox() || outro.getPtosBox() != 0
+                    || controleJogo.verificaNoPitLane(outro)) {
+                continue;
+            }
+            boolean ocupaAlvo = outro.getTracado() == alvo
+                    || (outro.getIndiceTracado() > 0 && outro.getTracadoAntigo() == alvo);
+            if (!ocupaAlvo) {
+                continue;
+            }
+            int d = noOutro.getIndex() - meuIndex;
+            if (d > n / 2) {
+                d -= n;
+            }
+            if (d < -n / 2) {
+                d += n;
+            }
+            if (d >= -100 && d <= 60) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Garante que o avanco do ciclo nunca entre nem atravesse a area do carro
+     * logo a frente na mesma linha. A penalidade de colisao apenas iguala o
+     * ganho ao do carro da frente: quando a aproximacao por ciclo e maior que
+     * a janela das areas de colisao (carro parado por acidente, largada,
+     * bandeirada) o carro de tras invadia ou passava por cima do da frente.
+     */
+    public long limitaAvancoCarroFrente(long avanco) {
+        if (avanco <= 0) {
+            return avanco;
+        }
+        if (controleJogo.isModoQualify()) {
+            return avanco;
+        }
+        No no = getNoAtual();
+        if (no == null || no.isBox() || controleJogo.verificaNoPitLane(this)) {
+            return avanco;
+        }
+        List<No> pista = controleJogo.getNosDaPista();
+        if (pista == null || pista.isEmpty()) {
+            return avanco;
+        }
+        int n = pista.size();
+        int meuIndex = no.getIndex();
+        int distanciaMinima = METADE_CARRO * 2;
+        long avancoLimitado = avanco;
+        List<Piloto> pilotos = controleJogo.getPilotos();
+        for (int i = 0; i < pilotos.size(); i++) {
+            Piloto outro = pilotos.get(i);
+            if (outro == null || outro.equals(this) || verificaNaoPrecisaDesviar(outro)) {
+                continue;
+            }
+            No noOutro = outro.getNoAtual();
+            if (noOutro == null || noOutro.isBox() || outro.getPtosBox() != 0
+                    || controleJogo.verificaNoPitLane(outro)) {
+                continue;
+            }
+            boolean mesmaLinha = outro.getTracado() == getTracado()
+                    || (outro.getIndiceTracado() > 0 && outro.getTracadoAntigo() == getTracado());
+            if (!mesmaLinha) {
+                continue;
+            }
+            int dOutro = noOutro.getIndex() - meuIndex;
+            if (dOutro < 0) {
+                dOutro += n;
+            }
+            if (dOutro == 0 && getPosicao() < outro.getPosicao()) {
+                continue;
+            }
+            if (dOutro > avancoLimitado + distanciaMinima) {
+                continue;
+            }
+            long novoAvanco = dOutro - distanciaMinima;
+            if (novoAvanco < 0) {
+                novoAvanco = 0;
+            }
+            if (novoAvanco < avancoLimitado) {
+                avancoLimitado = novoAvanco;
+            }
+        }
+        return avancoLimitado;
     }
 
     public void processaEscapadaDaPista() {
@@ -1835,7 +2009,12 @@ public class Piloto implements Serializable, PilotoSuave {
                 mudarTracado(2);
             } else if (getTracado() == 5) {
                 mudarTracado(1);
-            } else if (getNoAtual().getIndex() >= traz && getNoAtual().getIndex() <= frente) {
+            } else if (getNoAtual().getIndex() >= traz && getNoAtual().getIndex() <= frente
+                    && getIndiceTracado() == 0) {
+                /**
+                 * So forca o desvio com a animacao anterior concluida; o
+                 * branch roda a cada ciclo, entao apenas espera a vez.
+                 */
                 int novapos = 0;
                 if (pilotoBateu.getTracado() == 0) {
                     novapos = controleJogo.getRandom().intervalo(1, 2);
@@ -1857,6 +2036,10 @@ public class Piloto implements Serializable, PilotoSuave {
                 mudarTracado(0);
             }
 
+        } else if (tentarEscaparFilaIndiana()) {
+            /**
+             * Preso em fila indiana com tracado lateral livre: ja mudou.
+             */
         } else if ((evitaBaterCarroFrente && carroPilotoDaFrenteRetardatario != null
                 && getTracado() == carroPilotoDaFrenteRetardatario.getPiloto().getTracado())
                 || calculaDiffParaProximoRetardatario < (testeHabilidadePiloto() ? 100 : 150)) {
@@ -2039,6 +2222,13 @@ public class Piloto implements Serializable, PilotoSuave {
          * Verificar na entrada da curva e nao na area de escape
          */
         if (getTracado() == 4 || getTracado() == 5) {
+            return false;
+        }
+        /**
+         * Espera a animacao da troca de tracado atual terminar; escapar no
+         * meio dela resetava a interpolacao e o carro teleportava de linha.
+         */
+        if (getIndiceTracado() > 0) {
             return false;
         }
         if (pontoEscape == null) {
@@ -2825,6 +3015,10 @@ public class Piloto implements Serializable, PilotoSuave {
     }
 
     public boolean mudarTracado(int mudarTracado, boolean forcaMudar) {
+        return mudarTracado(mudarTracado, forcaMudar, false);
+    }
+
+    public boolean mudarTracado(int mudarTracado, boolean forcaMudar, boolean escapandoFila) {
         if (!forcaMudar && isRecebeuBanderada()) {
             return false;
         }
@@ -2874,7 +3068,25 @@ public class Piloto implements Serializable, PilotoSuave {
         if (getCarro().testeFreios()) {
             multi -= 2;
         }
-        if (!forcaMudar && getTracado() != 4 && getTracado() != 5 && getColisao() != null
+        /**
+         * Com atualizacao suave o carro desenhado fica atras da posicao real;
+         * mudar de tracado e voltar logo em seguida faz o carro suave cortar a
+         * linha de outro carro. O cooldown vale para qualquer mudanca, nao so
+         * quando ja existe colisao, exceto ida ao box e volta de escapada.
+         */
+        boolean cooldownSuave = controleJogo.isAtualizacaoSuave() && !isBox();
+        if (cooldownSuave) {
+            /**
+             * O intervalo minimo entre mudancas cobre a animacao inteira da
+             * troca (indiceTracado cai 2 por ciclo) mais uma folga, para a
+             * proxima mudanca nunca comecar com a anterior ainda animando.
+             */
+            double ciclosAnimacao = controleJogo.getCircuito().getIndiceTracado() / 2.0;
+            if (multi < ciclosAnimacao + 4) {
+                multi = ciclosAnimacao + 4;
+            }
+        }
+        if (!forcaMudar && getTracado() != 4 && getTracado() != 5 && (cooldownSuave || getColisao() != null)
                 && (agora - ultimaMudancaPos) < (controleJogo.tempoCicloCircuito() * multi)) {
             return false;
         }
@@ -2884,13 +3096,40 @@ public class Piloto implements Serializable, PilotoSuave {
         if (getTracado() == 2 && mudarTracado == 1) {
             return false;
         }
-        ultimaMudancaPos = System.currentTimeMillis();
-        if (!forcaMudar && verificaColisaoAoMudarDeTracado(mudarTracado)) {
+        if (!forcaMudar && !escapandoFila && verificaColisaoAoMudarDeTracado(mudarTracado)) {
             return false;
         } else {
+            /**
+             * Cooldown conta a partir da ultima mudanca efetivada; tentativas
+             * bloqueadas nao renovam o cooldown, senao um carro preso em fila
+             * nunca acumula tempo suficiente para conseguir mudar de tracado.
+             */
+            ultimaMudancaPos = System.currentTimeMillis();
+            int tracadoAntigoAnterior = getTracadoAntigo();
+            int indiceRestante = indiceTracado;
             setTracadoAntigo(getTracado());
             setTracado(mudarTracado);
             calculaIndiceTracado();
+            if (indiceRestante > 0) {
+                /**
+                 * Mudanca forcada no meio da animacao anterior. Se esta
+                 * voltando para a linha de origem, continua da posicao
+                 * lateral atual (espelha o progresso) em vez de teleportar
+                 * o carro para o inicio da nova interpolacao.
+                 */
+                if (mudarTracado == tracadoAntigoAnterior) {
+                    int continua = indiceTracado - indiceRestante;
+                    if (continua < 1) {
+                        continua = 1;
+                    }
+                    setIndiceTracado(continua);
+                }
+                if (Global.LOG_COLISAO) {
+                    Logger.logar("[TRACADO_RESET] piloto=" + getNome() + " de=" + getTracadoAntigo() + " para="
+                            + mudarTracado + " antAnterior=" + tracadoAntigoAnterior + " restante=" + indiceRestante
+                            + " forca=" + forcaMudar);
+                }
+            }
             return true;
         }
     }

--- a/src/test/java/br/f1mane/entidades/PilotoColisaoFilaTest.java
+++ b/src/test/java/br/f1mane/entidades/PilotoColisaoFilaTest.java
@@ -1,0 +1,228 @@
+package br.f1mane.entidades;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import br.f1mane.controles.InterfaceJogo;
+
+/**
+ * Cobre o limite de avanco contra o carro da frente (anti-atravessamento) e o
+ * escape de fila indiana: verificaTracadoLivreParaEscapar e a variante de
+ * mudarTracado que ignora a verificacao antiga de mudanca de tracado.
+ */
+class PilotoColisaoFilaTest {
+
+    private static final int TAMANHO_PISTA = 1000;
+    private static final int COMPRIMENTO_CARRO = Piloto.METADE_CARRO * 2;
+
+    private InterfaceJogo controleJogo;
+    private List<No> pista;
+    private List<Piloto> pilotos;
+
+    @BeforeEach
+    void setUp() {
+        pista = new ArrayList<>();
+        for (int i = 0; i < TAMANHO_PISTA; i++) {
+            No no = new No();
+            no.setIndex(i);
+            pista.add(no);
+        }
+        pilotos = new ArrayList<>();
+
+        controleJogo = mock(InterfaceJogo.class);
+        when(controleJogo.getNosDaPista()).thenReturn(pista);
+        when(controleJogo.getPilotos()).thenReturn(pilotos);
+        when(controleJogo.getPilotosCopia()).thenReturn(pilotos);
+        when(controleJogo.obterPista(any())).thenReturn(pista);
+        when(controleJogo.isModoQualify()).thenReturn(false);
+        when(controleJogo.isSafetyCarNaPista()).thenReturn(false);
+        when(controleJogo.isAtualizacaoSuave()).thenReturn(false);
+        when(controleJogo.verificaNoPitLane(any())).thenReturn(false);
+        when(controleJogo.tempoCicloCircuito()).thenReturn(200L);
+
+        GameRandom random = mock(GameRandom.class);
+        when(random.intervalo(1, 2)).thenReturn(1);
+        when(controleJogo.getRandom()).thenReturn(random);
+
+        Circuito circuito = mock(Circuito.class);
+        when(circuito.getIndiceTracado()).thenReturn(24.0);
+        when(circuito.getIndiceTracadoForaPista()).thenReturn(84.0);
+        when(controleJogo.getCircuito()).thenReturn(circuito);
+    }
+
+    private Piloto criarPiloto(String nome, int index, int tracado) {
+        Piloto piloto = new Piloto();
+        piloto.setNome(nome);
+        Carro carro = new Carro();
+        carro.setPiloto(piloto);
+        piloto.setCarro(carro);
+        piloto.setControleJogo(controleJogo);
+        piloto.setNoAtual(pista.get(index));
+        piloto.setTracado(tracado);
+        pilotos.add(piloto);
+        return piloto;
+    }
+
+    // ---- limitaAvancoCarroFrente ----
+
+    @Test
+    void limitaAvanco_carroParadoLogoAFrente_naoEntraNaAreaDele() {
+        Piloto atras = criarPiloto("Atras", 100, 0);
+        criarPiloto("Parado", 130, 0);
+
+        assertEquals(0, atras.limitaAvancoCarroFrente(50));
+    }
+
+    @Test
+    void limitaAvanco_carroAFrenteDentroDoAlcance_paraAUmCarroDeDistancia() {
+        Piloto atras = criarPiloto("Atras", 100, 0);
+        criarPiloto("Frente", 170, 0);
+
+        // avanca ate 170 - 100 - COMPRIMENTO_CARRO = 30
+        assertEquals(70 - COMPRIMENTO_CARRO, atras.limitaAvancoCarroFrente(50));
+    }
+
+    @Test
+    void limitaAvanco_carroDistante_naoLimita() {
+        Piloto atras = criarPiloto("Atras", 100, 0);
+        criarPiloto("Longe", 200, 0);
+
+        assertEquals(50, atras.limitaAvancoCarroFrente(50));
+    }
+
+    @Test
+    void limitaAvanco_carroEmOutroTracado_naoLimita() {
+        Piloto atras = criarPiloto("Atras", 100, 0);
+        criarPiloto("Lado", 130, 1);
+
+        assertEquals(50, atras.limitaAvancoCarroFrente(50));
+    }
+
+    @Test
+    void limitaAvanco_carroAFrenteAposVoltaCompleta_respeitaWrap() {
+        Piloto atras = criarPiloto("Atras", TAMANHO_PISTA - 10, 0);
+        criarPiloto("Frente", 20, 0);
+
+        assertEquals(0, atras.limitaAvancoCarroFrente(50));
+    }
+
+    @Test
+    void limitaAvanco_carroCruzandoMinhaLinha_limita() {
+        Piloto atras = criarPiloto("Atras", 100, 0);
+        Piloto cruzando = criarPiloto("Cruzando", 130, 1);
+        cruzando.setTracadoAntigo(0);
+        cruzando.setIndiceTracado(20);
+
+        assertEquals(0, atras.limitaAvancoCarroFrente(50));
+    }
+
+    // ---- verificaTracadoLivreParaEscapar ----
+
+    @Test
+    void tracadoLivre_filaIndianaNoMesmoTracado_naoBloqueiaEscape() {
+        Piloto preso = criarPiloto("Preso", 100, 0);
+        criarPiloto("FrenteFila", 140, 0);
+        criarPiloto("TrasFila", 60, 0);
+
+        assertTrue(preso.verificaTracadoLivreParaEscapar(1));
+    }
+
+    @Test
+    void tracadoLivre_carroNoAlvoAFrente_bloqueia() {
+        Piloto preso = criarPiloto("Preso", 100, 0);
+        criarPiloto("NoAlvo", 150, 1);
+
+        assertFalse(preso.verificaTracadoLivreParaEscapar(1));
+    }
+
+    @Test
+    void tracadoLivre_carroNoAlvoVindoAtras_bloqueia() {
+        Piloto preso = criarPiloto("Preso", 100, 0);
+        criarPiloto("VindoAtras", 30, 1);
+
+        assertFalse(preso.verificaTracadoLivreParaEscapar(1));
+    }
+
+    @Test
+    void tracadoLivre_carroNoAlvoBemLonge_naoBloqueia() {
+        Piloto preso = criarPiloto("Preso", 100, 0);
+        criarPiloto("Longe", 250, 1);
+
+        assertTrue(preso.verificaTracadoLivreParaEscapar(1));
+    }
+
+    @Test
+    void tracadoLivre_carroCruzandoParaOAlvo_bloqueia() {
+        Piloto preso = criarPiloto("Preso", 100, 0);
+        Piloto cruzando = criarPiloto("Cruzando", 130, 2);
+        cruzando.setTracadoAntigo(1);
+        cruzando.setIndiceTracado(20);
+
+        assertFalse(preso.verificaTracadoLivreParaEscapar(1));
+    }
+
+    // ---- mudarTracado escapando da fila ----
+
+    // ---- mudanca de tracado durante a animacao anterior ----
+
+    @Test
+    void mudarTracado_naoForcadaComAnimacaoEmAndamento_bloqueia() {
+        Piloto piloto = criarPiloto("Piloto", 100, 1);
+        piloto.setTracadoAntigo(0);
+        piloto.setIndiceTracado(10);
+
+        assertFalse(piloto.mudarTracado(0));
+        assertEquals(1, piloto.getTracado());
+    }
+
+    @Test
+    void mudarTracado_forcadaRevertendoNoMeioDaAnimacao_continuaDaPosicaoAtual() {
+        Piloto piloto = criarPiloto("Piloto", 100, 1);
+        piloto.setTracadoAntigo(0);
+        piloto.setIndiceTracado(10);
+
+        assertTrue(piloto.mudarTracado(0, true));
+        assertEquals(0, piloto.getTracado());
+        assertEquals(1, piloto.getTracadoAntigo());
+        // espelha o progresso: 24 (cheio) - 10 (restante) = 14
+        assertEquals(14, piloto.getIndiceTracado());
+    }
+
+    @Test
+    void mudarTracado_forcadaParaTerceiraLinhaNoMeioDaAnimacao_reiniciaAnimacao() {
+        Piloto piloto = criarPiloto("Piloto", 100, 0);
+        piloto.setTracadoAntigo(1);
+        piloto.setIndiceTracado(10);
+
+        assertTrue(piloto.mudarTracado(2, true));
+        assertEquals(2, piloto.getTracado());
+        assertEquals(0, piloto.getTracadoAntigo());
+        assertEquals(24, piloto.getIndiceTracado());
+    }
+
+    @Test
+    void mudarTracado_presoNaFila_verificacaoAntigaBloqueiaEscapeNao() {
+        Piloto preso = criarPiloto("Preso", 100, 0);
+        criarPiloto("FrenteFila", 140, 0);
+        criarPiloto("TrasFila", 60, 0);
+
+        // a verificacao antiga conta os vizinhos da propria fila e bloqueia
+        assertFalse(preso.mudarTracado(1));
+        assertEquals(0, preso.getTracado());
+
+        // escapando da fila a mudanca e permitida
+        assertTrue(preso.mudarTracado(1, false, true));
+        assertEquals(1, preso.getTracado());
+        assertEquals(0, preso.getTracadoAntigo());
+    }
+}

--- a/src/test/java/br/f1mane/entidades/PilotoPenalidadeEscapeFilaTest.java
+++ b/src/test/java/br/f1mane/entidades/PilotoPenalidadeEscapeFilaTest.java
@@ -1,0 +1,259 @@
+package br.f1mane.entidades;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.awt.Point;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import br.f1mane.controles.InterfaceJogo;
+
+/**
+ * Cobre a cadeia completa da correcao de overlap: deteccao de colisao com
+ * geometria real (areas dianteira/centro/traseira), penalidade de ganho
+ * (incluindo carro da frente cruzando a linha), contador de preso em fila com
+ * escape, e o cooldown de mudanca de tracado que cobre a animacao inteira.
+ */
+class PilotoPenalidadeEscapeFilaTest {
+
+    private static final int TAMANHO_PISTA = 1000;
+
+    private InterfaceJogo controleJogo;
+    private List<No> pista;
+    private List<Piloto> pilotos;
+
+    @BeforeEach
+    void setUp() {
+        pista = new ArrayList<>();
+        List<No> pista1 = new ArrayList<>();
+        List<No> pista2 = new ArrayList<>();
+        List<No> pista4 = new ArrayList<>();
+        List<No> pista5 = new ArrayList<>();
+        for (int i = 0; i < TAMANHO_PISTA; i++) {
+            pista.add(criarNo(i, i, 100));
+            pista1.add(criarNo(i, i, 76));
+            pista2.add(criarNo(i, i, 124));
+            pista4.add(null);
+            pista5.add(null);
+        }
+        pilotos = new ArrayList<>();
+
+        controleJogo = mock(InterfaceJogo.class);
+        when(controleJogo.getNosDaPista()).thenReturn(pista);
+        when(controleJogo.getNosDoBox()).thenReturn(new ArrayList<>());
+        when(controleJogo.getPilotos()).thenReturn(pilotos);
+        when(controleJogo.getPilotosCopia()).thenReturn(pilotos);
+        when(controleJogo.obterPista(any())).thenReturn(pista);
+        when(controleJogo.isModoQualify()).thenReturn(false);
+        when(controleJogo.isSafetyCarNaPista()).thenReturn(false);
+        when(controleJogo.isAtualizacaoSuave()).thenReturn(false);
+        when(controleJogo.verificaNoPitLane(any())).thenReturn(false);
+        when(controleJogo.tempoCicloCircuito()).thenReturn(200L);
+
+        GameRandom random = mock(GameRandom.class);
+        when(random.intervalo(1, 2)).thenReturn(1);
+        when(controleJogo.getRandom()).thenReturn(random);
+
+        Circuito circuito = mock(Circuito.class);
+        when(circuito.getIndiceTracado()).thenReturn(24.0);
+        when(circuito.getIndiceTracadoForaPista()).thenReturn(84.0);
+        when(circuito.getMultiplicadorLarguraPista()).thenReturn(1.0);
+        when(circuito.getPista1Full()).thenReturn(pista1);
+        when(circuito.getPista2Full()).thenReturn(pista2);
+        when(circuito.getPista4Full()).thenReturn(pista4);
+        when(circuito.getPista5Full()).thenReturn(pista5);
+        when(controleJogo.getCircuito()).thenReturn(circuito);
+    }
+
+    private No criarNo(int index, int x, int y) {
+        No no = new No();
+        no.setIndex(index);
+        no.setPoint(new Point(x, y));
+        return no;
+    }
+
+    private Piloto criarPiloto(String nome, int index, int tracado) {
+        Piloto piloto = new Piloto();
+        piloto.setNome(nome);
+        Carro carro = new Carro();
+        carro.setPiloto(piloto);
+        piloto.setCarro(carro);
+        piloto.setControleJogo(controleJogo);
+        piloto.setNoAtual(pista.get(index));
+        piloto.setTracado(tracado);
+        pilotos.add(piloto);
+        return piloto;
+    }
+
+    // ---- deteccao de colisao com geometria real ----
+
+    @Test
+    void processaColisao_carroLogoAFrenteMesmoTracado_detecta() {
+        Piloto atras = criarPiloto("Atras", 100, 0);
+        Piloto frente = criarPiloto("Frente", 130, 0);
+
+        atras.processaColisao();
+
+        assertEquals(frente, atras.getColisao());
+    }
+
+    @Test
+    void processaColisao_carroLongeMesmoTracado_naoDetecta() {
+        Piloto atras = criarPiloto("Atras", 100, 0);
+        criarPiloto("Longe", 300, 0);
+
+        atras.processaColisao();
+
+        assertNull(atras.getColisao());
+    }
+
+    // ---- penalidade de ganho ----
+
+    @Test
+    void processaPenalidadeColisao_mesmoTracado_ganhoLimitadoAoDaFrente() {
+        Piloto atras = criarPiloto("Atras", 100, 0);
+        Piloto frente = criarPiloto("Frente", 130, 0);
+        atras.setGanho(30);
+        frente.setGanho(0);
+
+        atras.processaColisao();
+        atras.processaPenalidadeColisao();
+
+        assertEquals(frente, atras.getColisao());
+        assertEquals(0, atras.getGanho());
+    }
+
+    @Test
+    void processaPenalidadeColisao_frenteCruzandoMinhaLinha_tambemLimita() {
+        Piloto atras = criarPiloto("Atras", 100, 0);
+        Piloto frente = criarPiloto("Frente", 130, 1);
+        // frente acabou de sair da linha 0 e ainda esta cruzando
+        frente.setTracadoAntigo(0);
+        frente.setIndiceTracado(20);
+        atras.setGanho(30);
+        frente.setGanho(0);
+
+        atras.processaColisao();
+        atras.processaPenalidadeColisao();
+
+        assertEquals(frente, atras.getColisao());
+        assertEquals(0, atras.getGanho());
+    }
+
+    // ---- contador de preso em fila e escape ----
+
+    private void prendeNaFila(Piloto atras, Piloto frente, int ciclos) {
+        atras.setColisao(frente);
+        atras.setGanho(5);
+        for (int i = 0; i < ciclos; i++) {
+            atras.processaPenalidadeColisao();
+        }
+    }
+
+    @Test
+    void tentarEscaparFilaIndiana_presoRastejando_escapaParaTracadoLivre() {
+        Piloto atras = criarPiloto("Atras", 100, 0);
+        Piloto frente = criarPiloto("Frente", 140, 0);
+        prendeNaFila(atras, frente, 8);
+
+        assertTrue(atras.tentarEscaparFilaIndiana());
+        assertEquals(1, atras.getTracado());
+    }
+
+    @Test
+    void tentarEscaparFilaIndiana_poucosCiclosPreso_naoEscapa() {
+        Piloto atras = criarPiloto("Atras", 100, 0);
+        Piloto frente = criarPiloto("Frente", 140, 0);
+        prendeNaFila(atras, frente, 7);
+
+        assertFalse(atras.tentarEscaparFilaIndiana());
+        assertEquals(0, atras.getTracado());
+    }
+
+    @Test
+    void tentarEscaparFilaIndiana_semColisaoContadorZera() {
+        Piloto atras = criarPiloto("Atras", 100, 0);
+        Piloto frente = criarPiloto("Frente", 140, 0);
+        prendeNaFila(atras, frente, 7);
+
+        // colisao some por um ciclo: contador zera
+        atras.setColisao(null);
+        atras.processaPenalidadeColisao();
+
+        prendeNaFila(atras, frente, 7);
+        assertFalse(atras.tentarEscaparFilaIndiana());
+    }
+
+    @Test
+    void tentarEscaparFilaIndiana_comSafetyCarNaPista_naoEscapa() {
+        Piloto atras = criarPiloto("Atras", 100, 0);
+        Piloto frente = criarPiloto("Frente", 140, 0);
+        prendeNaFila(atras, frente, 8);
+        when(controleJogo.isSafetyCarNaPista()).thenReturn(true);
+
+        assertFalse(atras.tentarEscaparFilaIndiana());
+        assertEquals(0, atras.getTracado());
+    }
+
+    @Test
+    void tentarEscaparFilaIndiana_ganhoNormal_naoAcumulaPreso() {
+        Piloto atras = criarPiloto("Atras", 100, 0);
+        Piloto frente = criarPiloto("Frente", 140, 0);
+        atras.setColisao(frente);
+        // seguindo em ritmo de corrida, nao rastejando
+        for (int i = 0; i < 20; i++) {
+            atras.setGanho(30);
+            atras.processaPenalidadeColisao();
+        }
+
+        assertFalse(atras.tentarEscaparFilaIndiana());
+    }
+
+    @Test
+    void tentarEscaparFilaIndiana_tracadoAlvoOcupado_naoEscapa() {
+        Piloto atras = criarPiloto("Atras", 100, 0);
+        Piloto frente = criarPiloto("Frente", 140, 0);
+        criarPiloto("NoTracado1", 130, 1);
+        criarPiloto("NoTracado2", 120, 2);
+        prendeNaFila(atras, frente, 8);
+
+        assertFalse(atras.tentarEscaparFilaIndiana());
+        assertEquals(0, atras.getTracado());
+    }
+
+    // ---- cooldown de mudanca de tracado cobre a animacao ----
+
+    @Test
+    void mudarTracado_comSuave_bloqueiaNovaMudancaLogoAposAnterior() {
+        when(controleJogo.isAtualizacaoSuave()).thenReturn(true);
+        Piloto piloto = criarPiloto("Piloto", 100, 0);
+
+        assertTrue(piloto.mudarTracado(1));
+        // simula a animacao concluida; o cooldown ainda deve segurar
+        piloto.setIndiceTracado(0);
+
+        assertFalse(piloto.mudarTracado(0));
+        assertEquals(1, piloto.getTracado());
+    }
+
+    @Test
+    void mudarTracado_forcada_ignoraCooldown() {
+        when(controleJogo.isAtualizacaoSuave()).thenReturn(true);
+        Piloto piloto = criarPiloto("Piloto", 100, 0);
+
+        assertTrue(piloto.mudarTracado(1));
+        piloto.setIndiceTracado(0);
+
+        assertTrue(piloto.mudarTracado(0, true));
+        assertEquals(0, piloto.getTracado());
+    }
+}


### PR DESCRIPTION
- Limite posicional de avanco (limitaAvancoCarroFrente): o carro nunca entra nem atravessa a area do carro logo a frente na mesma linha; a penalidade de colisao apenas igualava o ganho e, com aproximacao maior que a janela das areas de colisao (acidente, largada, bandeirada), o carro de tras invadia ou passava por cima do da frente.
- Penalidade de colisao tambem vale quando o carro da frente ainda esta cruzando a linha (mudou de tracado com o corpo na linha antiga).
- Escape de fila indiana: preso rastejando atras de carro na mesma linha por 8 ciclos, muda para tracado lateral comprovadamente livre; a verificacao antiga bloqueava a saida por causa dos vizinhos da fila.
- Cooldown de mudanca de tracado cobre a animacao inteira + folga, conta apenas mudancas efetivadas e mudancas forcadas nao resetam mais a animacao no meio (escapada e desvio de safety car esperam; reversao continua da posicao lateral atual).
- Logs de diagnostico [OVERLAP_REAL], [ESCAPE_FILA] e [TRACADO_RESET] atras de Global.LOG_COLISAO.
- 27 testes novos cobrindo clamp, penalidade, escape e cooldown.