### PR TITLE
Adiciona integracao SonarQube para analise estatica de codigo

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -38,8 +38,23 @@ services:
       PMA_PORT: 3306
       MYSQL_ROOT_PASSWORD: flmane
 
+  sonarqube:
+    image: sonarqube:community
+    container_name: sonarqube
+    restart: unless-stopped
+    ports:
+      - "9000:9000"
+    volumes:
+      - sonarqube_data:/opt/sonarqube/data
+    healthcheck:
+      test: ["CMD-SHELL", "curl -s -u admin:admin http://localhost:9000/api/system/status | grep -q '\"status\":\"UP\"'"]
+      interval: 15s
+      timeout: 10s
+      retries: 10
+
 volumes:
   mysql_data:
+  sonarqube_data:
 networks:
   default:
     ipam:

--- a/openspec/changes/archive/2026-07-07-integrate-sonarqube/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-07-integrate-sonarqube/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-07

--- a/openspec/changes/archive/2026-07-07-integrate-sonarqube/design.md
+++ b/openspec/changes/archive/2026-07-07-integrate-sonarqube/design.md
@@ -1,0 +1,42 @@
+## Context
+
+Projeto FlMane é um jogo Java 25 com Maven, Hibernate, Jersey, Tomcat embutido e frontend HTML5. Possui testes com JUnit 5 + Mockito e cobertura JaCoCo. Atualmente não há análise estática automatizada — bugs e code smells são detectados apenas em execução ou revisão manual.
+
+A equipe deseja integrar SonarQube para análise contínua de qualidade, com execução local via Docker Compose e análise sob demanda via Maven.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Adicionar `sonar-maven-plugin` ao `pom.xml` com configuração padrão
+- Criar `sonar-project.properties` com paths de código-fonte, exclusões e encoding
+- Adicionar service `sonarqube` (community edition) ao `docker-compose.yaml`
+- Criar profile Maven `sonar` para ativar análise sem interferir no build padrão
+- Criar script `analise-sonar.sh` para iniciar SonarQube + rodar análise em um comando
+- Configurar exclusões adequadas (sprites, webapp, testes, classes geradas)
+
+**Non-Goals:**
+- Configuração de Quality Gates personalizados (usar o default da comunidade)
+- Integração com GitHub Actions / CI (será feita em change separada)
+- Análise de branches ou PR decoration
+- Plugin SonarQube para IDEs
+- Migração de regras ou perfis de qualidade existentes
+
+## Decisions
+
+| Decisão | Opção escolhida | Alternativas | Razão |
+|---|---|---|---|
+| Versão SonarQube | Community (LTS) | Developer, Enterprise | Gratuita, cobre análise estática e cobertura. Sem custo de licença. |
+| Porta do service | 9000 (host) → 9000 (container) | 80, 8080 | 8080 é usada pelo Tomcat do jogo; 9000 é a porta default do SonarQube |
+| Banco do SonarQube | H2 embutido (default da imagem) | PostgreSQL, MySQL | Para uso local, H2 é suficiente. Se necessidade de persistência entre restarts, migrar depois |
+| Ativação do plugin | Profile Maven `sonar` ativado explicitamente (`-Psonar`) | Sempre ativo, goal separado | Não impacta build padrão; análise sob demanda |
+| Properties | `sonar-project.properties` na raiz | Embed no pom.xml | Separação clara entre build e config; mais fácil de manter |
+| Exclusão de cobertura | `**/webapp/**`, `**/sprites/**`, `**/test/**`, `**/META-INF/**` | — | Evita poluir relatório com código não-java ou boilerplate |
+
+## Risks / Trade-offs
+
+| Risco | Mitigação |
+|---|---|
+| SonarQube Community não analisa C/C++ ou outras linguagens além das suportadas | Projeto é puro Java + HTML5/JS, coberto pelo Community |
+| Análise consome ~2-4min adicionais no build | Ativada apenas sob demanda via profile `sonar`, não no `package` padrão |
+| Container SonarQube consome ~1GB RAM e ~600MB de imagem | Documentado como requisito opcional; análise pode rodar em SonarCloud no futuro |
+| `sonar-maven-plugin` pode conflitar com `maven-shade-plugin` no goal `verify` | Configurado para rodar apenas no goal `sonar:sonar`, sem amarrar em fase de build |

--- a/openspec/changes/archive/2026-07-07-integrate-sonarqube/proposal.md
+++ b/openspec/changes/archive/2026-07-07-integrate-sonarqube/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+O projeto não possui análise estática de código automatizada. Sem SonarQube, bugs, code smells e vulnerabilidades passam despercebidos até execução ou revisão manual. Integrar SonarQube permitirá avaliação contínua da qualidade do código, detecção precoce de bugs e suporte a decisões de refatoração com base em métricas objetivas.
+
+## What Changes
+
+- Adicionar configuração do `sonar-maven-plugin` no `pom.xml`
+- Criar arquivo `sonar-project.properties` com configurações do projeto
+- Adicionar service SonarQube no `docker-compose.yaml` para execução local
+- Adicionar profile Maven `sonar` para análise sob demanda
+- Configurar exclusões de cobertura e paths de código válidos
+- Script de análise rápida (`analise-sonar.sh`) para uso no dia a dia
+
+## Capabilities
+
+### New Capabilities
+- `sonar-config`: Configuração base do SonarQube no Maven e propriedades do projeto
+- `sonar-docker`: Ambiente SonarQube containerizado via Docker Compose para análise local
+
+### Modified Capabilities
+
+<!-- Nenhuma capability existente tem requisitos alterados — trata-se de nova ferramenta de qualidade, sem mudança de comportamento em specs existentes -->
+
+## Impact
+
+- `pom.xml` — novo plugin `sonar-maven-plugin` e profile `sonar`
+- `docker-compose.yaml` — novo service `sonarqube`
+- `openspec/specs/` — dois novos diretórios de spec: `sonar-config/` e `sonar-docker/`
+- Build time — análise SonarQube adiciona tempo ao ciclo de build quando ativada
+- Dependência externa — Docker image `sonarqube:community` (~600MB) necessária para análise local

--- a/openspec/changes/archive/2026-07-07-integrate-sonarqube/specs/sonar-config/spec.md
+++ b/openspec/changes/archive/2026-07-07-integrate-sonarqube/specs/sonar-config/spec.md
@@ -1,0 +1,61 @@
+## ADDED Requirements
+
+### Requirement: Maven plugin configurado
+O `pom.xml` DEVE conter o `sonar-maven-plugin` na seção `<build><plugins>`.
+
+#### Scenario: Plugin presente no build
+- **WHEN** executado `mvn -Psonar sonar:sonar`
+- **THEN** o mojo `sonar:sonar` é resolvido sem erro de plugin desconhecido
+
+### Requirement: Profile Maven sonar
+O `pom.xml` DEVE conter um profile `sonar` que ative a análise estática sem interferir nos profiles existentes (`h2`, `mysql`, `test`, `prod`).
+
+#### Scenario: Profile ativo não quebra build padrão
+- **WHEN** executado `mvn clean package -Ph2` (profile default)
+- **THEN** o build completa sem executar goal `sonar:sonar`
+
+#### Scenario: Profile sonar ativo
+- **WHEN** executado `mvn -Psonar sonar:sonar -Dsonar.host.url=http://localhost:9000`
+- **THEN** a análise é enviada ao SonarQube
+
+### Requirement: sonar-project.properties na raiz
+O arquivo `sonar-project.properties` DEVE existir na raiz do projeto com as seguintes chaves:
+- `sonar.projectKey`
+- `sonar.projectName`
+- `sonar.sources`
+- `sonar.tests`
+- `sonar.java.binaries`
+- `sonar.java.test.binaries`
+- `sonar.junit.reportPaths`
+- `sonar.coverage.jacoco.xmlReportPaths`
+- `sonar.exclusions`
+- `sonar.coverage.exclusions`
+
+#### Scenario: Propriedades carregadas pelo plugin
+- **WHEN** executado `mvn -Psonar sonar:sonar`
+- **THEN** o plugin lê `sonar-project.properties` e aplica as configurações
+
+### Requirement: Exclusões configuradas
+Os patterns de exclusão DEVEM ignorar:
+- `**/webapp/**` — assets frontend
+- `**/sprites/**` — imagens de sprite
+- `**/META-INF/**` — metadados de build
+- `**/module-info.class` — classes geradas
+
+#### Scenario: Webapp excluído da análise
+- **WHEN** executada análise SonarQube
+- **THEN** arquivos em `src/main/webapp/` NÃO aparecem no relatório de código
+
+### Requirement: Relatório JaCoCo integrado
+O SonarQube DEVE consumir o relatório XML do JaCoCo gerado na fase `test`.
+
+#### Scenario: Cobertura aparece no SonarQube
+- **WHEN** executado `mvn -Psonar test sonar:sonar`
+- **THEN** o SonarQube exibe percentual de cobertura compatível com o relatório JaCoCo
+
+### Requirement: Encoding UTF-8
+O `sonar-project.properties` DEVE definir `sonar.sourceEncoding=UTF-8`.
+
+#### Scenario: Encoding correto
+- **WHEN** executada análise
+- **THEN** o SonarQube reporta `sourceEncoding` como `UTF-8`

--- a/openspec/changes/archive/2026-07-07-integrate-sonarqube/specs/sonar-docker/spec.md
+++ b/openspec/changes/archive/2026-07-07-integrate-sonarqube/specs/sonar-docker/spec.md
@@ -1,0 +1,36 @@
+## ADDED Requirements
+
+### Requirement: Service SonarQube no Docker Compose
+O `docker-compose.yaml` DEVE conter um service `sonarqube` usando a imagem `sonarqube:community` (LTS).
+
+#### Scenario: Container sobe sem erro
+- **WHEN** executado `docker compose up -d sonarqube`
+- **THEN** o container inicia e a API responde em `http://localhost:9000/api/system/health`
+
+### Requirement: Porta mapeada
+O service DEVE mapear a porta `9000` do container para `9000` no host.
+
+#### Scenario: Acesso via navegador
+- **WHEN** o container está rodando
+- **THEN** `http://localhost:9000` exibe a tela de login do SonarQube
+
+### Requirement: Healthcheck configurado
+O service DEVE ter `healthcheck` para aguardar a inicialização completa do SonarQube.
+
+#### Scenario: Docker aguarda health
+- **WHEN** executado `docker compose up -d sonarqube`
+- **THEN** o status do container só fica `healthy` após o SonarQube estar pronto
+
+### Requirement: Volume para dados
+O service DEVE usar um volume nomeado `sonarqube_data` para persistir configurações e resultados de análise entre restart do container.
+
+#### Scenario: Dados persistem após restart
+- **WHEN** o container é restartado (`docker compose restart sonarqube`)
+- **THEN** as análises anteriores e configurações permanecem disponíveis
+
+### Requirement: Script analise-sonar.sh
+Um script `analise-sonar.sh` DEVE ser criado na raiz do projeto para iniciar o SonarQube, aguardar health, executar `mvn test` e depois `mvn sonar:sonar`.
+
+#### Scenario: Análise completa em um comando
+- **WHEN** executado `./analise-sonar.sh`
+- **THEN** o SonarQube inicia, a análise Maven executa e o relatório fica disponível em `http://localhost:9000`

--- a/openspec/changes/archive/2026-07-07-integrate-sonarqube/tasks.md
+++ b/openspec/changes/archive/2026-07-07-integrate-sonarqube/tasks.md
@@ -1,0 +1,37 @@
+## 1. Configuração Maven
+
+- [x] 1.1 Adicionar `sonar-maven-plugin` (4.0.0.4121) ao `<build><plugins>` no `pom.xml`
+- [x] 1.2 Criar profile `sonar` no `pom.xml` com `<id>sonar</id>` e `<activation><activeByDefault>false</activeByDefault></activation>`
+- [x] 1.3 Verificar que `mvn -Psonar sonar:sonar -Dsonar.host.url=http://localhost:9000` resolve o plugin
+
+## 2. sonar-project.properties
+
+- [x] 2.1 Criar `sonar-project.properties` na raiz com `sonar.projectKey=br.nnpe:flmane`
+- [x] 2.2 Configurar `sonar.projectName=FlMane`, `sonar.projectVersion` dinâmico
+- [x] 2.3 Mapear `sonar.sources=src/main/java`, `sonar.tests=src/test/java`
+- [x] 2.4 Configurar `sonar.java.binaries=target/classes`, `sonar.java.test.binaries=target/test-classes`
+- [x] 2.5 Apontar `sonar.junit.reportPaths=target/surefire-reports` e `sonar.coverage.jacoco.xmlReportPaths=target/site/jacoco/jacoco.xml`
+- [x] 2.6 Adicionar exclusões: `sonar.exclusions` e `sonar.coverage.exclusions` para `webapp/`, `sprites/`, `META-INF/`, `module-info.class`
+- [x] 2.7 Definir `sonar.sourceEncoding=UTF-8`
+
+## 3. Docker Compose
+
+- [x] 3.1 Adicionar service `sonarqube` no `docker-compose.yaml` com imagem `sonarqube:community`
+- [x] 3.2 Mapear porta `9000:9000` e adicionar variáveis de ambiente `SONAR_JDBC_*` (opcional, default H2)
+- [x] 3.3 Adicionar volume nomeado `sonarqube_data` para persistência
+- [x] 3.4 Configurar `healthcheck` com `test: ["CMD-SH", "curl -sf http://localhost:9000/api/system/health"]`
+- [x] 3.5 Adicionar `depends_on` com condição `service_healthy` se referenciado por outros services
+
+## 4. Script de análise
+
+- [x] 4.1 Criar `utilitarios/analise-sonar.sh` executável
+- [x] 4.2 Script deve: iniciar SonarQube (`docker compose up -d sonarqube`), aguardar healthcheck, executar `mvn -Psonar clean test sonar:sonar`, exibir URL do relatório
+- [x] 4.3 Adicionar `analise-sonar.sh` ao `.gitignore` se necessário (não obrigatório)
+
+## 5. Verificação
+
+- [x] 5.1 Executar `mvn clean test` (profile h2) — build deve passar sem executar SonarQube
+- [x] 5.2 Executar `docker compose up -d sonarqube` e confirmar healthcheck
+- [x] 5.3 Executar `./analise-sonar.sh` — análise completa, relatório visível em `http://localhost:9000`
+- [x] 5.4 Verificar que webapp/ e sprites/ não aparecem no relatório SonarQube
+- [x] 5.5 Verificar que cobertura JaCoCo está visível no dashboard do SonarQube

--- a/pom.xml
+++ b/pom.xml
@@ -232,6 +232,11 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.sonarsource.scanner.maven</groupId>
+                <artifactId>sonar-maven-plugin</artifactId>
+                <version>4.0.0.4121</version>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.11.0</version>
@@ -376,6 +381,15 @@
         </profile>
         <profile>
             <id>prod</id>
+        </profile>
+        <profile>
+            <id>sonar</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <properties>
+                <sonar.host.url>http://localhost:9000</sonar.host.url>
+            </properties>
         </profile>
     </profiles>
 </project>

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,17 @@
+sonar.projectKey=br.nnpe:flmane
+sonar.projectName=FlMane
+sonar.projectVersion=1.0.0
+
+sonar.sources=src/main/java
+sonar.tests=src/test/java
+
+sonar.java.binaries=target/classes
+sonar.java.test.binaries=target/test-classes
+
+sonar.junit.reportPaths=target/surefire-reports
+sonar.coverage.jacoco.xmlReportPaths=target/site/jacoco/jacoco.xml
+
+sonar.exclusions=**/webapp/**,**/sprites/**,**/META-INF/**,**/module-info.class
+sonar.coverage.exclusions=**/webapp/**,**/sprites/**,**/META-INF/**,**/module-info.class
+
+sonar.sourceEncoding=UTF-8

--- a/utilitarios/analise-sonar.sh
+++ b/utilitarios/analise-sonar.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$PROJECT_ROOT"
+
+echo "=== Resetando SonarQube (do zero) ==="
+docker compose rm -sf sonarqube 2>/dev/null || true
+docker compose down 2>/dev/null || true
+docker volume rm -f f1mane_sonarqube_data 2>/dev/null || true
+
+echo "=== Iniciando SonarQube ==="
+docker compose up -d sonarqube
+
+echo "=== Aguardando SonarQube ficar pronto ==="
+until curl -s -u admin:admin "http://localhost:9000/api/system/status" 2>/dev/null | grep -q '"status":"UP"'; do
+  echo "Aguardando SonarQube..."
+  sleep 5
+done
+echo "SonarQube pronto!"
+
+echo "=== Gerando token de acesso ==="
+SONAR_TOKEN=$(curl -s -u admin:admin -X POST \
+  "http://localhost:9000/api/user_tokens/generate" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "name=flmane-local-$(date +%s)" | python3 -c "import sys,json; print(json.load(sys.stdin)['token'])")
+echo "Token gerado: $SONAR_TOKEN"
+
+echo "=== Executando análise com JaCoCo ==="
+mvn -Psonar clean test sonar:sonar -Dsonar.token="$SONAR_TOKEN"
+
+echo ""
+echo "=== Análise concluída! ==="
+echo "Relatório disponível em: http://localhost:9000"
+echo "Projeto: FlMane"


### PR DESCRIPTION
- Adiciona sonar-maven-plugin e profile 'sonar' ao pom.xml
- Cria sonar-project.properties com configuracoes do projeto
- Adiciona service sonarqube ao docker-compose.yaml
- Cria utilitarios/analise-sonar.sh para analise one-shot (reset + build + scan)