### PR TITLE
Calcula velocidade real em km/h a partir da distancia do circuito

### DIFF
--- a/openspec/changes/archive/2026-07-11-refactor-velocidade-km-por-circuito/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-11-refactor-velocidade-km-por-circuito/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-11

--- a/openspec/changes/archive/2026-07-11-refactor-velocidade-km-por-circuito/design.md
+++ b/openspec/changes/archive/2026-07-11-refactor-velocidade-km-por-circuito/design.md
@@ -1,0 +1,120 @@
+## Context
+
+`Piloto.calculoVelocidade(double ganho)` (`Piloto.java:1306`) hoje é:
+
+```java
+private int calculoVelocidade(double ganho) {
+    int val = 290;
+    double porcent = getCarro().getPorcentagemCombustivel() / 100.0;
+    val += (21 - (porcent / 5.0));
+    boolean naReta = ...;
+    return Util.inteiro(((val * ganho * (naReta ? 1 : 0.7) / ganhoMax) + ganho * (naReta ? 1 : 0.7)));
+}
+```
+
+`ganho` é o quanto o índice do piloto avança na lista de nós da pista (`getNosDaPista()`, que é `circuito.getPistaFull()` — a versão interpolada/densa do traçado) a cada ciclo de simulação (`tempoCicloCircuito()` = `circuito.getCiclo()` ms). Não há nenhuma relação com o tamanho real do circuito — `330`/`320`/`290` são números de balanceamento escolhidos por tentativa, sem lastro físico.
+
+`Circuito.distanciaKm` (adicionado em `circuito-info-editor`) guarda a extensão real da pista. Os dois circuitos que já têm o valor preenchido guardam **metros** num campo `int` (Albert Park = `5303`, Interlagos = `4309`, batendo com os comprimentos oficiais de 5,303 km e 4,309 km) — apesar do nome do campo e do label do editor ("Distância (km)") sugerirem quilômetros. Isso é consequência de `distanciaKm` ter sido convertido de `double` pra `int` (commit `922d33e0`/seguinte) sem ajustar a escala: um `int` não representa `5.303` km sem perda, então o valor informado passou a ser em metros. O restante desta mudança assume esse fato (ver Open Questions).
+
+35 dos 37 circuitos ainda têm `distanciaKm == 0` (nunca foi preenchido). Para esses, não existe dado real de extensão pra calcular km/h — a fórmula nova precisa de um fallback.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Velocidade instantânea (`Piloto.velocidade`) calculada a partir do avanço real de índice por ciclo (`ganho`), relativizado ao comprimento real do circuito (`distanciaKm`) e ao tempo de ciclo (`tempoCicloCircuito()`), resultando num km/h fisicamente coerente para circuitos com `distanciaKm` informado.
+- Teto de ~370–375 km/h: a velocidade calculada nunca ultrapassa 375; ao atingir a faixa de teto, o valor passa a oscilar entre 370 e 375 (efeito de "limitador"), em vez de travar num número fixo.
+- Circuitos com `distanciaKm == 0` continuam com o comportamento atual (fórmula antiga), sem regressão visual pros 35 circuitos ainda não preenchidos.
+- Consolidar as constantes de teto de velocidade hoje duplicadas (`290`, `320`, `330`) numa única referência usada tanto no cálculo quanto na escala de cor do velocímetro (`PainelCircuito.desenhaVelocidade`).
+- Efeito artificial de "reta sustentada": depois de 3s contínuos numa reta (fora do traçado de fuga), a velocidade passa a subir sozinha até o teto, ignorando o `ganho` real, simulando o carro esticando a reta até o limite — pedido explicitamente como uma dramatização, não como física mais precisa.
+
+**Non-Goals:**
+- Preencher `distanciaKm` dos outros 35 circuitos (trabalho de conteúdo/dados, não desta mudança).
+- Renomear o campo `distanciaKm` ou mudar sua unidade/serialização (fica pra uma mudança futura, se o time decidir formalizar "metros").
+- Alterar a física de ultrapassagem/colisão/turbulência que também consome `ganho` — só o cálculo de velocidade exibida muda.
+- Alterar `calculaVelocidadeExibir()` (suavização da agulha) — ela já limita o incremento por ciclo e vai naturalmente amortecer a oscilação do teto num flutuar sutil, sem precisar de mudança própria.
+
+## Decisions
+
+### 1. Fórmula: km/h real a partir de índice/ciclo e `distanciaKm`
+
+```
+kmPorNo   = (distanciaKm / 1000.0) / nosDaPista.size()   // km reais por unidade de índice
+kmPorCiclo = ganho * kmPorNo
+ciclosPorHora = 3_600_000.0 / tempoCicloCircuito()        // ms -> ciclos/hora
+velocidadeKmh = kmPorCiclo * ciclosPorHora
+```
+
+Simplificando: `velocidadeKmh = (ganho * distanciaKm * 3600.0) / (nosDaPista.size() * tempoCicloCircuito())`, com `distanciaKm` tratado como metros (÷1000 embutido no `3600.0`, já que `3_600_000 / 1000 = 3600`).
+
+Isso é exatamente o pedido: "referência de movimento, índice/pixel, com relação ao tamanho do circuito, extensão em quilômetros, calculando quilometragem por hora" — usa o mesmo `ganho` que já move o piloto (sem introduzir um segundo sistema de física), só reprojeta esse avanço em km/h reais usando dados que já existem (`nosDaPista.size()`, `distanciaKm`, `tempoCicloCircuito()`).
+
+**Alternativa considerada:** manter a fórmula antiga e só reescalar seu resultado pra "parecer" km/h (ex.: multiplicar por um fator fixo). Rejeitada — não usaria `distanciaKm` de verdade, então dois circuitos com extensões bem diferentes continuariam mostrando a mesma velocidade pro mesmo `ganho`, o que é exatamente o problema que a proposta quer resolver.
+
+### 2. Teto com oscilação, não clamp fixo
+
+Quando `velocidadeKmh` calculada (real ou fallback) ultrapassa `TETO_VELOCIDADE_MIN` (370), o valor exibido passa a alternar entre `TETO_VELOCIDADE_MIN` (370) e `TETO_VELOCIDADE_MAX` (375) a cada ciclo em que o piloto seguir "no limite" — mesmo padrão sobe/desce já usado em `OcilaCor.ocila()`, mas como estado por `Piloto` (não por chave estática global, já que cada piloto precisa oscilar de forma independente): dois campos novos (`velocidadeTetoOscilacao`, `velocidadeTetoSubindo`) e um pequeno método que empurra o valor 1 km/h por ciclo em direção ao extremo oposto ao chegar em cada ponta.
+
+Isso nunca deixa `velocidade` passar de 375. Como `calculaVelocidadeExibir()` só aproxima `velocidadeExibir` de `velocidade` (nunca ultrapassa o alvo), o valor exibido na tela também fica implicitamente limitado a 375 — sem precisar de um teto redundante na camada de exibição.
+
+**Alternativa considerada:** clamp simples (`Math.min(velocidade, 375)`), sem oscilação. Rejeitada por não atender ao pedido explícito do usuário ("nunca passasse disso... ficasse oscilando entre esses valores") — um clamp fixo trava a agulha, não dá a sensação de limitador.
+
+### 3. Fallback para `distanciaKm == 0`
+
+Quando `circuito.getDistanciaKm() == 0`, `calculoVelocidade` mantém a fórmula antiga (constantes 290/ganhoMax) intacta — sem dividir por zero e sem regressão visual nos 35 circuitos que ainda não têm a distância cadastrada. O teto com oscilação (370–375) passa a valer também pro fallback, já que é uma melhoria independente de `distanciaKm` (hoje o teto informal já gira em torno de 320–330).
+
+**Alternativa considerada:** exigir `distanciaKm` preenchido em todos os circuitos antes de fazer essa mudança (migração de dados primeiro). Rejeitada — bloquearia a entrega por um trabalho de conteúdo sem relação com a lógica, e o fallback já cobre o caso com segurança.
+
+### 4. Constante única de teto
+
+Extrair `TETO_VELOCIDADE_MIN = 370` e `TETO_VELOCIDADE_MAX = 375` (ou nome equivalente) como constantes em `Piloto` (ou `Global`, se outras classes precisarem — hoje só `Piloto` e `PainelCircuito` usam número de teto). `PainelCircuito.desenhaVelocidade()` troca o `330` fixo da escala de cor (`porcentVermelho100Verde0((100 * velocidade / 330))`) pela nova constante de teto, então a barra de cor sempre bate 100% exatamente no teto real.
+
+### 5. Reta sustentada: rampa artificial só no valor exibido, nunca na velocidade real
+
+Primeira versão desta decisão aplicava o incremento artificial dentro de `calculoVelocidade` (a velocidade "real"), mas o usuário pediu explicitamente pra restringir o efeito ao "valor visual da quilometragem" — a velocidade real também alimenta `ControleJogosServer.dadosParciais.velocidade` (sincronizada com clientes multiplayer) e a intensidade dos efeitos visuais de chuva em `PainelCircuito` (`piloto.getVelocidade() / 320.0`), então injetar um valor artificial ali corromperia esses consumidores, não só o velocímetro. A implementação final move o efeito inteiro pra `calculaVelocidadeExibir()` (que já é, por definição, só a camada de exibição/suavização da agulha), deixando `calculoVelocidade`/`Piloto.velocidade` inteiramente livres da rampa.
+
+Um contador por piloto (`tempoContinuoNaRetaMs`) acumula `tempoCicloCircuito()` a cada ciclo em que `noAtual.verificaRetaOuLargada()` for verdadeiro e o piloto não estiver no traçado de fuga (`getTracado() == 4 || == 5`); zera assim que uma dessas condições deixar de valer. Ao atingir `LIMIAR_RETA_SUSTENTADA_MS` (3000ms), `calculaVelocidadeExibir()` para de suavizar `velocidadeExibir` em direção a `velocidade` e passa a incrementar `velocidadeExibir` do ciclo anterior em `INCREMENTO_VELOCIDADE_RETA_SUSTENTADA` (2 km/h), sujeito a um teto com oscilação 370–375 próprio (`velocidadeExibirTetoOscilacao`/`velocidadeExibirTetoSubindo` — campos e lógica de ping-pong deliberadamente duplicados dos equivalentes `velocidadeTeto*` usados por `aplicaTetoVelocidade`, e não compartilhados: os dois métodos rodam no mesmo ciclo de jogo — `processarCiclo` chama `calculoVelocidade` antes de `calculaVelocidadeExibir` chamar essa rampa — então usar o mesmo estado faria os dois pipelines pisarem um no outro).
+
+Por que ler `velocidadeExibir` (o campo, valor do ciclo anterior) em vez de recalcular do zero: mantém uma subida contínua (sem salto) a partir de onde a agulha já estava, em vez de reiniciar de um valor arbitrário — o mesmo raciocínio da primeira versão, só que agora aplicado ao valor exibido em vez do real.
+
+Por que também checar o traçado de fuga (e não só o tipo do nó): o mesmo problema já resolvido em `PilotoGanhoTracadoDeFugaTest` — o nó da pista principal (`noAtual`) não muda de tipo quando o piloto está fisicamente na escapada (traçado 4/5), já que o índice usado é sempre o da pista principal. Sem essa checagem, um piloto na escapada sobre um trecho de reta da pista principal ativaria a subida artificial mesmo estando fisicamente numa via de fuga, o que o usuário pediu explicitamente pra excluir.
+
+**Alternativa considerada (rejeitada nesta correção):** manter o efeito em `calculoVelocidade`/`velocidade`. Rejeitada porque `velocidade` não é só um valor de exibição — é lido por `ControleJogosServer` (rede) e pelos efeitos de chuva (`PainelCircuito`), então a rampa artificial vazaria pra esses consumidores. Movida integralmente pra `calculaVelocidadeExibir()`/`velocidadeExibir`, que é exclusivamente a camada visual.
+
+**Alternativa considerada, depois adotada numa correção seguinte:** gatilho também checando a zona de frenagem (não ativar a rampa se o piloto estiver numa zona de frenagem, mesmo ainda em nó de reta). Inicialmente rejeitada — ver decisão 6, que reverte essa rejeição a pedido do usuário.
+
+### 6. Zona de frenagem desativa o incremento artificial (sem resetar a contagem)
+
+A decisão 5 rejeitou gatear a rampa por frenagem, mas o usuário pediu explicitamente: "o incremento artificial de velocidade [deveria ser] desativado na zona de frenagem". `calculaVelocidadeExibir()` agora também checa `controleJogo.isNoZonaFrenagem(noAtual)` — o mesmo detector de zona de frenagem já usado por `processaFreioNaReta()` e pelas specs `zona-frenagem-*` (pré-calculado por circuito: nós de reta na aproximação de um cluster de curva baixa, mais o próprio cluster) — antes de ativar `aplicaRetaSustentadaNaVelocidadeExibir()`: `tempoContinuoNaRetaMs >= LIMIAR_RETA_SUSTENTADA_MS && !controleJogo.isNoZonaFrenagem(noAtual)`.
+
+Por que `isNoZonaFrenagem` e não `isFreiandoReta()`: `isNoZonaFrenagem` é a detecção geométrica direta ("este nó pertence a uma zona de frenagem"), pré-computada por circuito e independente de estado de execução — bate literalmente com o termo que o usuário usou ("zona de frenagem"). `isFreiandoReta()` é um flag de comportamento em tempo de execução, setado por `processaFreioNaReta()` com lógica adicional (só dispara se a próxima curva for especificamente curva baixa, com multiplicadores probabilísticos) — um proxy indireto e mais restrito pra a mesma ideia.
+
+Por que só suspender o incremento, sem resetar `tempoContinuoNaRetaMs`: a zona de frenagem é o trecho final de uma reta (nós de reta na aproximação, mais o cluster de curva baixa); resetar o contador ao entrá-la faria a rampa nunca reengatar caso a reta continuasse depois (situação rara, mas incoerente) e, mais relevante, faria o piloto precisar de outros 3s inteiros de reta depois de qualquer frenagem antes de a rampa voltar — mesmo já tendo passado bastante tempo numa reta contínua antes da zona. Suspender (sem zerar) faz o incremento retomar no mesmo ciclo em que o piloto sai da zona, se a contagem já estava acima do limiar, o que corresponde ao comportamento esperado: a "artificialidade" desliga só durante a frenagem, sem penalizar o resto da reta sustentada.
+
+### 7. Incremento tênue acima de 300 km/h (teto só em retas bem longas)
+
+O usuário pediu: "acima dos 300 km/h... o incremento gradual [deveria] se tornar mais tênue para que o teto só fosse atingido em retas muito longas". `calculaIncrementoRetaSustentada()` substitui o incremento fixo de 2 km/h/ciclo por três faixas, todas lidas a partir de `getVelocidadeExibir()` (o valor sendo incrementado, não `velocidade`):
+
+- Abaixo de `LIMIAR_VELOCIDADE_INCREMENTO_TENUE` (300): incremento cheio, `INCREMENTO_VELOCIDADE_RETA_SUSTENTADA` (2) por ciclo — comportamento inalterado nessa faixa.
+- De 300 até `LIMIAR_VELOCIDADE_INCREMENTO_MUITO_TENUE` (340): metade, 1 por ciclo.
+- A partir de 340: só 1 km/h a cada `CICLOS_POR_INCREMENTO_MUITO_TENUE` (3) ciclos, usando `tempoContinuoNaRetaMs / tempoCicloCircuito()` como relógio (`% 3 == 0`) — sem precisar de um campo de estado novo, já que `tempoContinuoNaRetaMs` já existe e cresce 1 `tempoCicloCircuito()` por ciclo enquanto a reta sustentada estiver ativa.
+
+Por que faixas discretas (2 → 1 → 1-a-cada-3-ciclos) em vez de uma curva contínua de desaceleração: com `INCREMENTO_VELOCIDADE_RETA_SUSTENTADA` valendo só 2 km/h, uma fórmula proporcional contínua (`incremento = INCREMENTO * (teto - atual) / (teto - 300)`) colapsa quase toda a faixa 300–370 pra "0 ou 1" por causa de arredondamento/truncamento inteiro — ou seja, na prática vira a mesma coisa que uma faixa discreta, só que com uma fórmula bem menos legível. As faixas discretas replicam o padrão que `calculaVelocidadeExibir()` já usa pra `incAcell`/`incFreiada` (degraus fixos em 100/200 km/h), mantendo o mesmo idioma do arquivo.
+
+Por que reusar `tempoContinuoNaRetaMs` em vez de outro contador: evita adicionar mais um campo (`@JsonIgnore`) só pra saber "faz quantos ciclos que estou nessa faixa" — como o piloto só entra na faixa "muito tênue" depois de já estar continuamente na reta sustentada, o número de ciclos decorridos desde o início da reta (dividido pelo tamanho do ciclo) já serve como um relógio determinístico o bastante pra intercalar os incrementos.
+
+O teto continua tecnicamente alcançável (nunca estagna em 0 pra sempre) — só que numa reta de ~340 até 370 km/h a 1km/h a cada 3 ciclos, são ~90 ciclos só nesse trecho (~13-20s dependendo do `ciclo` do circuito), ou seja, uma reta bem longa — nem toda pista de F1 tem uma reta capaz de sustentar isso sem cruzar uma curva ou zona de frenagem antes.
+
+## Risks / Trade-offs
+
+- [`distanciaKm` armazenado em metros mas nomeado/rotulado como "km"] → Mitigação: fórmula trata explicitamente o valor como metros (`distanciaKm / 1000.0`); documentar essa decisão no código (comentário) pra não reintroduzir o bug de escala numa mudança futura.
+- [Fórmula real pode gerar velocidades muito baixas ou instáveis pra combinações incomuns de `distanciaKm`/`nosDaPista.size()`/`ciclo`, já que esses valores foram calibrados independentemente ao longo do tempo] → Mitigação: teto de 370–375 já limita o topo; não há garantia formal de piso, mas o comportamento herdado (ganho→velocidade proporcional) evita valores negativos ou zerados fora de paradas reais (safety car, box, grid).
+- [Apenas 2 circuitos exercitam a fórmula nova hoje — cobertura de teste limitada em cenários reais de jogo] → Mitigação: testes unitários com `distanciaKm` sintético cobrindo faixas baixas/médias/teto, sem depender só dos XMLs existentes.
+
+## Migration Plan
+
+Sem migração de dados — mudança é só de código, e o fallback garante que os 35 circuitos sem `distanciaKm` não mudam de comportamento. Nenhum arquivo de circuito precisa ser tocado. Rollback é reverter o commit; nenhum estado persistido é criado por esta mudança (o teto/oscilação vive só em memória, por piloto, durante a corrida).
+
+## Open Questions
+
+- `distanciaKm` guardar metros com nome/label de "km" é uma inconsistência pré-existente (fora do escopo desta mudança corrigir) — vale abrir uma mudança futura pra renomear o campo (`distanciaMetros`) ou ajustar o label/parse do editor pra aceitar km com casas decimais?
+- O teto 370–375 km/h é um valor fixo pra todos os circuitos, mesmo os que não tem distanciaKm (fallback). Faz sentido variar esse teto por circuito (ex.: retas mais longas permitem topo mais alto) numa iteração futura, ou 370–375 fixo é suficiente por ora?

--- a/openspec/changes/archive/2026-07-11-refactor-velocidade-km-por-circuito/proposal.md
+++ b/openspec/changes/archive/2026-07-11-refactor-velocidade-km-por-circuito/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+O velocímetro exibido durante a corrida (`Piloto.calculoVelocidade()` / `PainelCircuito.desenhaVelocidade()`) hoje é um número de balanceamento de jogo sem relação com a física real: usa constantes soltas e divergentes (290, 320 e 330) e é derivado apenas do `ganho` (avanço de índice por ciclo), sem nenhuma referência ao tamanho real do circuito. Agora que `Circuito.distanciaKm` guarda a extensão real do autódromo (ver `circuito-info-editor`), dá para calcular uma velocidade km/h de verdade a partir do quanto o piloto avança na pista por ciclo, relativizado ao comprimento real da volta — com um teto realista (~370–375 km/h) em vez de um número arbitrário.
+
+## What Changes
+
+- Nova fórmula de velocidade instantânea: converte o `ganho` (avanço de índice por ciclo) em km/h real, usando `distanciaKm` do circuito e a quantidade de nós da pista (`getNosDaPista().size()`) como referência de "quanto índice = quantos km", e `tempoCicloCircuito()` (ms/ciclo) como referência de tempo.
+- Teto de velocidade (~370–375 km/h): ao atingir o teto, a velocidade não passa dele — em vez de travar num valor fixo, oscila suavemente entre os dois extremos da faixa (efeito parecido com o "sobe/desce" já usado em `OcilaCor`), simulando o carro no limite.
+- Circuitos sem `distanciaKm` informado (valor 0 — hoje é o caso de 35 dos 37 circuitos) mantêm o comportamento atual (fórmula antiga baseada só em `ganho`), já que não há dado real de extensão para calcular km/h de verdade.
+- Consolidação das constantes de velocidade máxima hoje espalhadas (290 em `calculoVelocidade`, 320 em outro cálculo de giro do motor, 330 na escala de cor do velocímetro) numa única referência de teto, usada tanto para o cálculo quanto para a escala de cor do painel.
+
+## Capabilities
+
+### New Capabilities
+- `velocidade-real-km-h`: como a velocidade instantânea do piloto é calculada a partir do avanço real na pista e da extensão do circuito em km, incluindo o comportamento de teto com oscilação e o fallback para circuitos sem `distanciaKm`.
+
+### Modified Capabilities
+(nenhuma — `circuito-info-editor` continua descrevendo `distanciaKm` como hoje; esta mudança só passa a consumir esse valor já existente, sem alterar seu requisito.)
+
+## Impact
+
+- `src/main/java/br/f1mane/entidades/Piloto.java` — `calculoVelocidade(double ganho)` (linha ~1306) e possivelmente `calculaVelocidadeExibir()` (linha ~3695, que usa o valor bruto pra suavizar a agulha).
+- `src/main/java/br/f1mane/visao/PainelCircuito.java` — `desenhaVelocidade()` (linha ~5054), especificamente a escala de cor `porcentVermelho100Verde0((100 * velocidade / 330))`.
+- `src/main/java/br/f1mane/entidades/Circuito.java` — nenhuma mudança de schema; só leitura de `getDistanciaKm()` e `getNosDaPista()` em novo local.
+- Nenhum arquivo de circuito (`*_mro_meta.xml`) precisa mudar — comportamento novo só se ativa para circuitos que já têm `distanciaKm` != 0.
+- Testes unitários de `Piloto`/`PainelCircuito` relacionados a velocidade precisam cobrir: cálculo com `distanciaKm` informado, fallback com `distanciaKm` zero, e o comportamento de oscilação no teto.

--- a/openspec/changes/archive/2026-07-11-refactor-velocidade-km-por-circuito/specs/velocidade-real-km-h/spec.md
+++ b/openspec/changes/archive/2026-07-11-refactor-velocidade-km-por-circuito/specs/velocidade-real-km-h/spec.md
@@ -1,0 +1,85 @@
+## ADDED Requirements
+
+### Requirement: Velocidade instantânea é calculada a partir do avanço real na pista e da extensão do circuito
+
+Quando `circuito.getDistanciaKm()` for diferente de zero, `Piloto.calculoVelocidade(double ganho)` SHALL calcular a velocidade em km/h a partir do avanço de índice por ciclo (`ganho`), do total de nós de uma volta (`controleJogo.getNosDaPista().size()`), da extensão real do circuito em metros (`circuito.getDistanciaKm()`) e da duração do ciclo de simulação (`controleJogo.tempoCicloCircuito()`), segundo a fórmula `velocidadeKmh = (ganho * distanciaKm * 3600.0) / (nosDaPista.size() * tempoCicloCircuito())`, antes de aplicar o teto descrito no requisito de teto com oscilação.
+
+#### Scenario: Circuito com distanciaKm informado usa a fórmula real
+- **WHEN** o piloto avança `ganho` unidades de índice num ciclo, num circuito com `distanciaKm` diferente de zero
+- **THEN** a velocidade calculada é `(ganho * distanciaKm * 3600.0) / (nosDaPista.size() * tempoCicloCircuito())`, arredondada para inteiro, antes do teto
+
+#### Scenario: Circuitos com extensões diferentes produzem velocidades diferentes para o mesmo avanço
+- **WHEN** dois circuitos com `distanciaKm` diferentes têm o mesmo número de nós por volta, o mesmo `ciclo` e o piloto avança o mesmo `ganho` em cada um
+- **THEN** a velocidade calculada é proporcional a `distanciaKm` de cada circuito, ou seja, os dois valores são diferentes entre si
+
+### Requirement: Circuitos sem distanciaKm informado mantêm a fórmula anterior
+
+Quando `circuito.getDistanciaKm()` for igual a zero, `Piloto.calculoVelocidade(double ganho)` SHALL continuar usando a fórmula anterior baseada em `ganho`/`ganhoMax` e no percentual de combustível, sem tentar dividir por `distanciaKm` nem por `nosDaPista.size()` pra esse propósito. O teto com oscilação SHALL valer igualmente para esse fallback.
+
+#### Scenario: Circuito sem distanciaKm não muda de comportamento de cálculo
+- **WHEN** um circuito tem `distanciaKm == 0` e o piloto avança `ganho` num ciclo
+- **THEN** a velocidade calculada (antes do teto) é igual à que a fórmula existente antes desta mudança produziria para o mesmo `ganho`, percentual de combustível e situação de reta/curva
+
+### Requirement: Velocidade nunca ultrapassa o teto e oscila ao atingi-lo
+
+A velocidade final de um piloto (após a fórmula real ou o fallback) SHALL nunca ultrapassar `TETO_VELOCIDADE_MAX` (375 km/h). Sempre que o valor calculado alcançar ou ultrapassar `TETO_VELOCIDADE_MIN` (370 km/h), a velocidade exibida para aquele piloto naquele ciclo SHALL vir de uma oscilação que alterna gradualmente entre `TETO_VELOCIDADE_MIN` e `TETO_VELOCIDADE_MAX` (subindo até o topo, depois descendo até o piso, repetindo), em vez de permanecer fixa num único valor.
+
+#### Scenario: Velocidade calculada abaixo do teto não é alterada
+- **WHEN** a velocidade calculada (real ou fallback) é menor que `TETO_VELOCIDADE_MIN`
+- **THEN** a velocidade final do piloto é exatamente o valor calculado, sem oscilação
+
+#### Scenario: Velocidade calculada no teto ou acima passa a oscilar
+- **WHEN** a velocidade calculada é maior ou igual a `TETO_VELOCIDADE_MIN` em ciclos consecutivos
+- **THEN** a velocidade final do piloto varia entre `TETO_VELOCIDADE_MIN` e `TETO_VELOCIDADE_MAX` ao longo desses ciclos, subindo até `TETO_VELOCIDADE_MAX` e depois descendo até `TETO_VELOCIDADE_MIN`, sem nunca ultrapassar `TETO_VELOCIDADE_MAX` nem ficar abaixo de `TETO_VELOCIDADE_MIN`
+
+#### Scenario: Oscilação do teto é independente por piloto
+- **WHEN** dois pilotos diferentes atingem o teto de velocidade em ciclos diferentes
+- **THEN** cada piloto oscila entre `TETO_VELOCIDADE_MIN` e `TETO_VELOCIDADE_MAX` de forma independente, sem compartilhar fase de oscilação com o outro piloto
+
+### Requirement: Reta sustentada aciona uma subida artificial gradual até o teto, só no valor exibido
+
+Quando o piloto permanecer num nó de reta/largada contínuo (`No.verificaRetaOuLargada()`) por `LIMIAR_RETA_SUSTENTADA_MS` (3000ms) ou mais, sem estar no traçado de fuga (`getTracado() == 4 || getTracado() == 5`) e sem estar na zona de frenagem (`controleJogo.isNoZonaFrenagem(noAtual)`), `Piloto.calculaVelocidadeExibir()` SHALL ignorar a velocidade real (`Piloto.velocidade`, resultado de `calculoVelocidade`) e, em vez disso, incrementar `velocidadeExibir` do ciclo anterior a cada ciclo, sujeito a um teto com oscilação (370–375) equivalente ao já descrito pra velocidade real, mas com estado de oscilação próprio. `Piloto.velocidade` (a velocidade real, consumida por `ControleJogosServer` no multiplayer e pelos efeitos visuais de chuva em `PainelCircuito`) SHALL NOT ser alterada por esse efeito — ele existe exclusivamente no valor exibido no velocímetro. O tamanho do incremento SHALL ficar mais tênue conforme `velocidadeExibir` sobe: `INCREMENTO_VELOCIDADE_RETA_SUSTENTADA` (2 km/h) por ciclo abaixo de `LIMIAR_VELOCIDADE_INCREMENTO_TENUE` (300 km/h); metade disso (1 km/h) por ciclo entre 300 e `LIMIAR_VELOCIDADE_INCREMENTO_MUITO_TENUE` (340 km/h); e, a partir de 340 km/h, apenas 1 km/h a cada `CICLOS_POR_INCREMENTO_MUITO_TENUE` (3) ciclos — de forma que o teto (370–375) só seja efetivamente alcançado em retas contínuas bem longas. A contagem de tempo contínuo em reta SHALL zerar assim que o nó atual deixar de ser reta/largada, ou o piloto entrar no traçado de fuga, mesmo que o nó da pista principal naquele índice continue marcado como reta — nesses casos, `calculaVelocidadeExibir()` volta a usar a suavização normal (em direção a `velocidade`) imediatamente, sem o incremento artificial. Estar na zona de frenagem SHALL apenas suspender a aplicação do incremento (voltando à suavização normal enquanto durar), sem zerar a contagem de tempo contínuo em reta — ao sair da zona de frenagem ainda na mesma reta, com a contagem já acima do limiar, o incremento artificial SHALL retomar no mesmo ciclo, sem esperar novos 3000ms.
+
+#### Scenario: Menos de 3 segundos contínuos em reta usa a suavização normal
+- **WHEN** o piloto está num nó de reta/largada há menos de 3000ms contínuos
+- **THEN** `velocidadeExibir` continua sendo suavizada em direção a `velocidade` pela lógica existente, sem o incremento artificial
+
+#### Scenario: 3 segundos contínuos em reta, fora da zona de frenagem, ativam a subida artificial no valor exibido
+- **WHEN** o piloto completa 3000ms contínuos num nó de reta/largada (fora do traçado de fuga e fora da zona de frenagem), com `velocidadeExibir` abaixo de 300 km/h
+- **THEN** a partir desse ciclo, `velocidadeExibir` de cada ciclo seguinte (enquanto continuar na mesma condição e abaixo de 300 km/h) é o `velocidadeExibir` do ciclo anterior mais `INCREMENTO_VELOCIDADE_RETA_SUSTENTADA` (2 km/h), ignorando `velocidade` daquele ciclo
+
+#### Scenario: Entre 300 e 340 km/h, o incremento cai pela metade
+- **WHEN** a reta sustentada está ativa e `velocidadeExibir` está entre `LIMIAR_VELOCIDADE_INCREMENTO_TENUE` (300) e `LIMIAR_VELOCIDADE_INCREMENTO_MUITO_TENUE` (340) km/h
+- **THEN** cada ciclo incrementa `velocidadeExibir` em apenas 1 km/h, em vez dos 2 km/h usados abaixo de 300
+
+#### Scenario: Acima de 340 km/h, o incremento fica muito tênue
+- **WHEN** a reta sustentada está ativa e `velocidadeExibir` está em ou acima de `LIMIAR_VELOCIDADE_INCREMENTO_MUITO_TENUE` (340) km/h
+- **THEN** `velocidadeExibir` só sobe 1 km/h a cada `CICLOS_POR_INCREMENTO_MUITO_TENUE` (3) ciclos consecutivos nessa condição, permanecendo igual nos demais ciclos, de forma que alcançar o teto (370–375) a partir daí exige uma reta contínua consideravelmente mais longa
+
+#### Scenario: Zona de frenagem desativa o incremento artificial, mesmo com a contagem acima do limiar
+- **WHEN** o piloto está num nó marcado como zona de frenagem (`controleJogo.isNoZonaFrenagem`), mesmo que a contagem de tempo contínuo em reta já esteja acima de 3000ms
+- **THEN** `velocidadeExibir` continua sendo suavizada em direção a `velocidade` pela lógica existente naquele ciclo, sem o incremento artificial
+
+#### Scenario: Sair da zona de frenagem reativa o incremento artificial sem reiniciar a contagem
+- **WHEN** o piloto sai da zona de frenagem ainda num nó de reta/largada contínuo, com a contagem de tempo contínuo em reta já acima de 3000ms
+- **THEN** o incremento artificial em `velocidadeExibir` retoma no mesmo ciclo, sem precisar acumular novos 3000ms
+
+#### Scenario: Velocidade real nunca é alterada pelo efeito de reta sustentada
+- **WHEN** o piloto está em reta sustentada havendo o incremento artificial ativo em `velocidadeExibir`
+- **THEN** `Piloto.velocidade` (e, portanto, `ControleJogosServer.dadosParciais.velocidade` e a intensidade dos efeitos de chuva em `PainelCircuito`) continua sendo só o resultado de `calculoVelocidade`, sem nenhuma influência do incremento artificial
+
+#### Scenario: Sair da reta interrompe a subida artificial imediatamente
+- **WHEN** o piloto estava em reta sustentada (subida artificial ativa em `velocidadeExibir`) e o nó atual muda para curva alta ou curva baixa
+- **THEN** no ciclo seguinte `velocidadeExibir` volta a ser suavizado em direção a `velocidade` pela lógica existente, sem continuar o incremento artificial, e a contagem de tempo contínuo em reta reinicia do zero
+
+#### Scenario: Traçado de fuga nunca ativa a reta sustentada
+- **WHEN** o piloto está no traçado de fuga (`getTracado()` 4 ou 5), mesmo que o nó da pista principal naquele índice seja marcado como reta
+- **THEN** a contagem de tempo contínuo em reta nunca avança, e a subida artificial nunca é ativada em `velocidadeExibir` enquanto o piloto permanecer no traçado de fuga
+
+### Requirement: Escala de cor do velocímetro usa a mesma referência de teto
+
+`PainelCircuito.desenhaVelocidade()` SHALL usar `TETO_VELOCIDADE_MAX` (em vez do valor fixo `330` hoje usado) como referência de 100% na escala de cor do velocímetro (`OcilaCor.porcentVermelho100Verde0`).
+
+#### Scenario: Velocímetro fica na cor mais "quente" exatamente no teto
+- **WHEN** a velocidade exibida de um piloto é igual a `TETO_VELOCIDADE_MAX`
+- **THEN** a escala de cor do velocímetro corresponde a 100%, igual ao que ocorria antes com o valor fixo `330` quando a velocidade chegava a 330

--- a/openspec/changes/archive/2026-07-11-refactor-velocidade-km-por-circuito/tasks.md
+++ b/openspec/changes/archive/2026-07-11-refactor-velocidade-km-por-circuito/tasks.md
@@ -1,0 +1,55 @@
+## 1. Constantes de teto
+
+- [x] 1.1 Adicionar `TETO_VELOCIDADE_MIN` (370) e `TETO_VELOCIDADE_MAX` (375) como constantes em `Piloto.java`. (Nota: `290`, base da fórmula de fallback, e `320`, usado em efeito visual de chuva não coberto por nenhuma tarefa, foram mantidos intactos — só o `330` da tarefa 4.1 era de fato uma referência de teto.)
+
+## 2. Cálculo de velocidade real
+
+- [x] 2.1 Em `Piloto.calculoVelocidade(double ganho)`, quando `controleJogo.getCircuito().getDistanciaKm() != 0`, calcular `velocidadeKmh = (ganho * distanciaKm * 3600.0) / (nosDaPista.size() * tempoCicloCircuito())` (arredondando pra inteiro), em vez da fórmula baseada em `ganhoMax`/combustível.
+- [x] 2.2 Manter a fórmula atual (`val`/`ganhoMax`/combustível) como fallback quando `getDistanciaKm() == 0`.
+- [x] 2.3 Extrair o cálculo real pra um método privado dedicado (`calculoVelocidadeReal`), mantendo `calculoVelocidade` como o ponto único que decide entre fórmula real e fallback.
+
+## 3. Teto com oscilação
+
+- [x] 3.1 Adicionar campos de estado por piloto (`velocidadeTetoOscilacao`, `velocidadeTetoSubindo`) em `Piloto.java`.
+- [x] 3.2 Implementar a lógica de oscilação: quando o valor calculado (real ou fallback) for `>= TETO_VELOCIDADE_MIN`, avançar a oscilação um passo em direção ao extremo oposto (subindo até `TETO_VELOCIDADE_MAX`, depois descendo até `TETO_VELOCIDADE_MIN`, repetindo), e usar esse valor oscilado como velocidade final em vez do valor calculado.
+- [x] 3.3 Quando o valor calculado cair abaixo de `TETO_VELOCIDADE_MIN` novamente, voltar a usar o valor calculado diretamente (sem oscilação) e resetar o estado de oscilação.
+
+## 4. Velocímetro (UI)
+
+- [x] 4.1 Em `PainelCircuito.desenhaVelocidade()`, trocar o `330` fixo em `OcilaCor.porcentVermelho100Verde0((100 * velocidade / 330))` pela constante `TETO_VELOCIDADE_MAX` de `Piloto`.
+
+## 5. Testes
+
+- [x] 5.1 Teste unitário: circuito com `distanciaKm` informado produz velocidade proporcional a `ganho`, `distanciaKm`, `nosDaPista.size()` e `tempoCicloCircuito()`, batendo com a fórmula (antes do teto).
+- [x] 5.2 Teste unitário: dois circuitos com `distanciaKm` diferentes (mesmo número de nós e mesmo ciclo) produzem velocidades diferentes para o mesmo `ganho`.
+- [x] 5.3 Teste unitário: circuito com `distanciaKm == 0` produz o mesmo resultado que a fórmula antiga (fallback), pro mesmo `ganho`/combustível/reta-ou-curva.
+- [x] 5.4 Teste unitário: velocidade calculada acima de `TETO_VELOCIDADE_MIN` nunca resulta em valor final acima de `TETO_VELOCIDADE_MAX`, e o valor final oscila entre `TETO_VELOCIDADE_MIN` e `TETO_VELOCIDADE_MAX` ao longo de ciclos consecutivos nessa condição.
+- [x] 5.5 Teste unitário: dois pilotos distintos que atingem o teto em ciclos diferentes oscilam de forma independente (não compartilham fase).
+- [x] 5.6 Rodar `mvn test` completo pra garantir que nenhum teste existente de `Piloto`/`PainelCircuito`/`ControleCorrida` quebrou com a mudança de fórmula. (556 testes, 0 falhas, 0 erros, 2 skipped — igual ao baseline.)
+
+## 6. Validação manual
+
+- [x] 6.1 Conferir, com o circuito real do Albert Park (`distanciaKm=5303`, `pistaFull.size()=18575`, `ciclo=140`), que `calculoVelocidadeReal` produz valores plausíveis pra faixa de `ganho` já usada pelo jogo (10-50 nas escadas de reta/curva de `calculaModificadorPrincipal`): 73–367 km/h, e que valores de `ganho` mais altos (60-80, fora da faixa normal) disparam corretamente o teto de 370–375. (`./simulacao.sh` citado no CLAUDE.md não existe no repo — validação feita carregando o `Circuito` real via `CarregadorRecursos.carregarCircuito` e chamando o cálculo diretamente, sem depender da simulação gráfica Swing.)
+
+## 7. Reta sustentada (rampa artificial até o teto, só no valor exibido)
+
+- [x] 7.1 Adicionar campo `tempoContinuoNaRetaMs` em `Piloto.java` e o método `atualizaTempoContinuoNaReta()`, que acumula `tempoCicloCircuito()` por ciclo enquanto `noAtual.verificaRetaOuLargada()` for verdadeiro e o piloto não estiver no traçado de fuga (`getTracado() == 4 || == 5`), zerando assim que uma das duas condições deixar de valer.
+- [x] 7.2 Adicionar constantes `LIMIAR_RETA_SUSTENTADA_MS` (3000) e `INCREMENTO_VELOCIDADE_RETA_SUSTENTADA` (2).
+- [x] 7.3 (Revertido e movido — ver 7.6) Primeira versão aplicava o incremento em `calculoVelocidade`/`velocidade`; corrigido a pedido do usuário ("incremento somente no valor visual da quilometragem") pra não vazar pra `ControleJogosServer` (rede) nem pros efeitos de chuva em `PainelCircuito`, que também leem `velocidade`.
+- [x] 7.4 Testes unitários (versão final, sobre `velocidadeExibir`): (a) abaixo de 3s a suavização normal continua valendo; (b) ao cruzar 3s, `velocidadeExibir` passa a subir +2/ciclo ignorando `velocidade`; (c) mudar pra um nó de curva interrompe a rampa e volta à suavização normal no ciclo seguinte; (d) estar no traçado de fuga nunca ativa a rampa, mesmo com o nó da pista principal marcado como reta; (e) `velocidade` (real) nunca é alterada pela rampa, em nenhum dos cenários acima.
+- [x] 7.5 Rodar `mvn test` completo pra confirmar que nenhum teste existente quebrou. (560 testes, 0 falhas, 0 erros, 2 skipped.)
+- [x] 7.6 Mover o efeito de `calculoVelocidade` pra `calculaVelocidadeExibir()`: novos campos `velocidadeExibirTetoOscilacao`/`velocidadeExibirTetoSubindo` (estado de teto/oscilação dedicado, independente de `velocidadeTetoOscilacao`/`velocidadeTetoSubindo` usados pela velocidade real) e método `aplicaRetaSustentadaNaVelocidadeExibir()`, que incrementa `velocidadeExibir` em vez de `velocidade`. `calculoVelocidade` volta a conter só a fórmula real/fallback + teto, sem nenhuma menção a reta sustentada.
+
+## 8. Zona de frenagem desativa o incremento artificial
+
+- [x] 8.1 Em `calculaVelocidadeExibir()`, gatear a ativação de `aplicaRetaSustentadaNaVelocidadeExibir()` também em `!controleJogo.isNoZonaFrenagem(noAtual)`, além do limiar de 3s já existente — sem resetar `tempoContinuoNaRetaMs` ao entrar na zona (só suspende a aplicação, retomando no mesmo ciclo em que sai da zona se a contagem já estiver acima do limiar).
+- [x] 8.2 Testes unitários: (a) na zona de frenagem, a rampa nunca ativa mesmo com 4s contínuos em reta; (b) ao sair da zona de frenagem com a contagem já acima do limiar, a rampa ativa no mesmo ciclo, sem precisar de novos 3s.
+- [x] 8.3 Rodar `mvn test` completo pra confirmar que nenhum teste existente quebrou. (561 testes, 0 falhas, 0 erros, 2 skipped.)
+
+## 9. Incremento tênue acima de 300 km/h
+
+- [x] 9.1 Adicionar constantes `LIMIAR_VELOCIDADE_INCREMENTO_TENUE` (300), `LIMIAR_VELOCIDADE_INCREMENTO_MUITO_TENUE` (340) e `CICLOS_POR_INCREMENTO_MUITO_TENUE` (3) em `Piloto.java`.
+- [x] 9.2 Extrair `calculaIncrementoRetaSustentada()`: abaixo de 300, retorna `INCREMENTO_VELOCIDADE_RETA_SUSTENTADA` (2); de 300 a 340, retorna 1; a partir de 340, retorna 1 só quando `(tempoContinuoNaRetaMs / tempoCicloCircuito()) % CICLOS_POR_INCREMENTO_MUITO_TENUE == 0`, senão 0 (reaproveitando `tempoContinuoNaRetaMs`, sem novo campo de estado).
+- [x] 9.3 `aplicaRetaSustentadaNaVelocidadeExibir()` passa a somar `calculaIncrementoRetaSustentada()` em vez do incremento fixo.
+- [x] 9.4 Testes unitários: (a) abaixo de 300, incremento continua 2; (b) entre 300 e 340, incremento cai pra 1; (c) a partir de 340, só incrementa 1 a cada 3 ciclos, ficando parado nos outros dois.
+- [x] 9.5 Rodar `mvn test` completo pra confirmar que nenhum teste existente quebrou. (564 testes, 0 falhas, 0 erros, 2 skipped.)

--- a/openspec/specs/velocidade-real-km-h/spec.md
+++ b/openspec/specs/velocidade-real-km-h/spec.md
@@ -1,0 +1,91 @@
+# velocidade-real-km-h
+
+## Purpose
+
+Calcular a velocidade instantânea de um piloto (`Piloto.calculoVelocidade`) em km/h reais a partir da extensão física do circuito (`circuito.getDistanciaKm()`), em vez de apenas de um percentual arbitrário de "ganho máximo", preservando compatibilidade com circuitos que ainda não têm essa distância cadastrada. Também cobre o teto de velocidade com oscilação (para evitar um valor travado e "artificial" no limite), o efeito de subida gradual em retas sustentadas (puramente cosmético, no valor exibido no velocímetro) e o ajuste da escala de cor do velocímetro para usar a mesma referência de teto.
+
+## Requirements
+
+### Requirement: Velocidade instantânea é calculada a partir do avanço real na pista e da extensão do circuito
+
+Quando `circuito.getDistanciaKm()` for diferente de zero, `Piloto.calculoVelocidade(double ganho)` SHALL calcular a velocidade em km/h a partir do avanço de índice por ciclo (`ganho`), do total de nós de uma volta (`controleJogo.getNosDaPista().size()`), da extensão real do circuito em metros (`circuito.getDistanciaKm()`) e da duração do ciclo de simulação (`controleJogo.tempoCicloCircuito()`), segundo a fórmula `velocidadeKmh = (ganho * distanciaKm * 3600.0) / (nosDaPista.size() * tempoCicloCircuito())`, antes de aplicar o teto descrito no requisito de teto com oscilação.
+
+#### Scenario: Circuito com distanciaKm informado usa a fórmula real
+- **WHEN** o piloto avança `ganho` unidades de índice num ciclo, num circuito com `distanciaKm` diferente de zero
+- **THEN** a velocidade calculada é `(ganho * distanciaKm * 3600.0) / (nosDaPista.size() * tempoCicloCircuito())`, arredondada para inteiro, antes do teto
+
+#### Scenario: Circuitos com extensões diferentes produzem velocidades diferentes para o mesmo avanço
+- **WHEN** dois circuitos com `distanciaKm` diferentes têm o mesmo número de nós por volta, o mesmo `ciclo` e o piloto avança o mesmo `ganho` em cada um
+- **THEN** a velocidade calculada é proporcional a `distanciaKm` de cada circuito, ou seja, os dois valores são diferentes entre si
+
+### Requirement: Circuitos sem distanciaKm informado mantêm a fórmula anterior
+
+Quando `circuito.getDistanciaKm()` for igual a zero, `Piloto.calculoVelocidade(double ganho)` SHALL continuar usando a fórmula anterior baseada em `ganho`/`ganhoMax` e no percentual de combustível, sem tentar dividir por `distanciaKm` nem por `nosDaPista.size()` pra esse propósito. O teto com oscilação SHALL valer igualmente para esse fallback.
+
+#### Scenario: Circuito sem distanciaKm não muda de comportamento de cálculo
+- **WHEN** um circuito tem `distanciaKm == 0` e o piloto avança `ganho` num ciclo
+- **THEN** a velocidade calculada (antes do teto) é igual à que a fórmula existente antes desta mudança produziria para o mesmo `ganho`, percentual de combustível e situação de reta/curva
+
+### Requirement: Velocidade nunca ultrapassa o teto e oscila ao atingi-lo
+
+A velocidade final de um piloto (após a fórmula real ou o fallback) SHALL nunca ultrapassar `TETO_VELOCIDADE_MAX` (375 km/h). Sempre que o valor calculado alcançar ou ultrapassar `TETO_VELOCIDADE_MIN` (370 km/h), a velocidade exibida para aquele piloto naquele ciclo SHALL vir de uma oscilação que alterna gradualmente entre `TETO_VELOCIDADE_MIN` e `TETO_VELOCIDADE_MAX` (subindo até o topo, depois descendo até o piso, repetindo), em vez de permanecer fixa num único valor.
+
+#### Scenario: Velocidade calculada abaixo do teto não é alterada
+- **WHEN** a velocidade calculada (real ou fallback) é menor que `TETO_VELOCIDADE_MIN`
+- **THEN** a velocidade final do piloto é exatamente o valor calculado, sem oscilação
+
+#### Scenario: Velocidade calculada no teto ou acima passa a oscilar
+- **WHEN** a velocidade calculada é maior ou igual a `TETO_VELOCIDADE_MIN` em ciclos consecutivos
+- **THEN** a velocidade final do piloto varia entre `TETO_VELOCIDADE_MIN` e `TETO_VELOCIDADE_MAX` ao longo desses ciclos, subindo até `TETO_VELOCIDADE_MAX` e depois descendo até `TETO_VELOCIDADE_MIN`, sem nunca ultrapassar `TETO_VELOCIDADE_MAX` nem ficar abaixo de `TETO_VELOCIDADE_MIN`
+
+#### Scenario: Oscilação do teto é independente por piloto
+- **WHEN** dois pilotos diferentes atingem o teto de velocidade em ciclos diferentes
+- **THEN** cada piloto oscila entre `TETO_VELOCIDADE_MIN` e `TETO_VELOCIDADE_MAX` de forma independente, sem compartilhar fase de oscilação com o outro piloto
+
+### Requirement: Reta sustentada aciona uma subida artificial gradual até o teto, só no valor exibido
+
+Quando o piloto permanecer num nó de reta/largada contínuo (`No.verificaRetaOuLargada()`) por `LIMIAR_RETA_SUSTENTADA_MS` (3000ms) ou mais, sem estar no traçado de fuga (`getTracado() == 4 || getTracado() == 5`) e sem estar na zona de frenagem (`controleJogo.isNoZonaFrenagem(noAtual)`), `Piloto.calculaVelocidadeExibir()` SHALL ignorar a velocidade real (`Piloto.velocidade`, resultado de `calculoVelocidade`) e, em vez disso, incrementar `velocidadeExibir` do ciclo anterior a cada ciclo, sujeito a um teto com oscilação (370–375) equivalente ao já descrito pra velocidade real, mas com estado de oscilação próprio. `Piloto.velocidade` (a velocidade real, consumida por `ControleJogosServer` no multiplayer e pelos efeitos visuais de chuva em `PainelCircuito`) SHALL NOT ser alterada por esse efeito — ele existe exclusivamente no valor exibido no velocímetro. O tamanho do incremento SHALL ficar mais tênue conforme `velocidadeExibir` sobe: `INCREMENTO_VELOCIDADE_RETA_SUSTENTADA` (2 km/h) por ciclo abaixo de `LIMIAR_VELOCIDADE_INCREMENTO_TENUE` (300 km/h); metade disso (1 km/h) por ciclo entre 300 e `LIMIAR_VELOCIDADE_INCREMENTO_MUITO_TENUE` (340 km/h); e, a partir de 340 km/h, apenas 1 km/h a cada `CICLOS_POR_INCREMENTO_MUITO_TENUE` (3) ciclos — de forma que o teto (370–375) só seja efetivamente alcançado em retas contínuas bem longas. A contagem de tempo contínuo em reta SHALL zerar assim que o nó atual deixar de ser reta/largada, ou o piloto entrar no traçado de fuga, mesmo que o nó da pista principal naquele índice continue marcado como reta — nesses casos, `calculaVelocidadeExibir()` volta a usar a suavização normal (em direção a `velocidade`) imediatamente, sem o incremento artificial. Estar na zona de frenagem SHALL apenas suspender a aplicação do incremento (voltando à suavização normal enquanto durar), sem zerar a contagem de tempo contínuo em reta — ao sair da zona de frenagem ainda na mesma reta, com a contagem já acima do limiar, o incremento artificial SHALL retomar no mesmo ciclo, sem esperar novos 3000ms.
+
+#### Scenario: Menos de 3 segundos contínuos em reta usa a suavização normal
+- **WHEN** o piloto está num nó de reta/largada há menos de 3000ms contínuos
+- **THEN** `velocidadeExibir` continua sendo suavizada em direção a `velocidade` pela lógica existente, sem o incremento artificial
+
+#### Scenario: 3 segundos contínuos em reta, fora da zona de frenagem, ativam a subida artificial no valor exibido
+- **WHEN** o piloto completa 3000ms contínuos num nó de reta/largada (fora do traçado de fuga e fora da zona de frenagem), com `velocidadeExibir` abaixo de 300 km/h
+- **THEN** a partir desse ciclo, `velocidadeExibir` de cada ciclo seguinte (enquanto continuar na mesma condição e abaixo de 300 km/h) é o `velocidadeExibir` do ciclo anterior mais `INCREMENTO_VELOCIDADE_RETA_SUSTENTADA` (2 km/h), ignorando `velocidade` daquele ciclo
+
+#### Scenario: Entre 300 e 340 km/h, o incremento cai pela metade
+- **WHEN** a reta sustentada está ativa e `velocidadeExibir` está entre `LIMIAR_VELOCIDADE_INCREMENTO_TENUE` (300) e `LIMIAR_VELOCIDADE_INCREMENTO_MUITO_TENUE` (340) km/h
+- **THEN** cada ciclo incrementa `velocidadeExibir` em apenas 1 km/h, em vez dos 2 km/h usados abaixo de 300
+
+#### Scenario: Acima de 340 km/h, o incremento fica muito tênue
+- **WHEN** a reta sustentada está ativa e `velocidadeExibir` está em ou acima de `LIMIAR_VELOCIDADE_INCREMENTO_MUITO_TENUE` (340) km/h
+- **THEN** `velocidadeExibir` só sobe 1 km/h a cada `CICLOS_POR_INCREMENTO_MUITO_TENUE` (3) ciclos consecutivos nessa condição, permanecendo igual nos demais ciclos, de forma que alcançar o teto (370–375) a partir daí exige uma reta contínua consideravelmente mais longa
+
+#### Scenario: Zona de frenagem desativa o incremento artificial, mesmo com a contagem acima do limiar
+- **WHEN** o piloto está num nó marcado como zona de frenagem (`controleJogo.isNoZonaFrenagem`), mesmo que a contagem de tempo contínuo em reta já esteja acima de 3000ms
+- **THEN** `velocidadeExibir` continua sendo suavizada em direção a `velocidade` pela lógica existente naquele ciclo, sem o incremento artificial
+
+#### Scenario: Sair da zona de frenagem reativa o incremento artificial sem reiniciar a contagem
+- **WHEN** o piloto sai da zona de frenagem ainda num nó de reta/largada contínuo, com a contagem de tempo contínuo em reta já acima de 3000ms
+- **THEN** o incremento artificial em `velocidadeExibir` retoma no mesmo ciclo, sem precisar acumular novos 3000ms
+
+#### Scenario: Velocidade real nunca é alterada pelo efeito de reta sustentada
+- **WHEN** o piloto está em reta sustentada havendo o incremento artificial ativo em `velocidadeExibir`
+- **THEN** `Piloto.velocidade` (e, portanto, `ControleJogosServer.dadosParciais.velocidade` e a intensidade dos efeitos de chuva em `PainelCircuito`) continua sendo só o resultado de `calculoVelocidade`, sem nenhuma influência do incremento artificial
+
+#### Scenario: Sair da reta interrompe a subida artificial imediatamente
+- **WHEN** o piloto estava em reta sustentada (subida artificial ativa em `velocidadeExibir`) e o nó atual muda para curva alta ou curva baixa
+- **THEN** no ciclo seguinte `velocidadeExibir` volta a ser suavizado em direção a `velocidade` pela lógica existente, sem continuar o incremento artificial, e a contagem de tempo contínuo em reta reinicia do zero
+
+#### Scenario: Traçado de fuga nunca ativa a reta sustentada
+- **WHEN** o piloto está no traçado de fuga (`getTracado()` 4 ou 5), mesmo que o nó da pista principal naquele índice seja marcado como reta
+- **THEN** a contagem de tempo contínuo em reta nunca avança, e a subida artificial nunca é ativada em `velocidadeExibir` enquanto o piloto permanecer no traçado de fuga
+
+### Requirement: Escala de cor do velocímetro usa a mesma referência de teto
+
+`PainelCircuito.desenhaVelocidade()` SHALL usar `TETO_VELOCIDADE_MAX` (em vez do valor fixo `330` hoje usado) como referência de 100% na escala de cor do velocímetro (`OcilaCor.porcentVermelho100Verde0`).
+
+#### Scenario: Velocímetro fica na cor mais "quente" exatamente no teto
+- **WHEN** a velocidade exibida de um piloto é igual a `TETO_VELOCIDADE_MAX`
+- **THEN** a escala de cor do velocímetro corresponde a 100%, igual ao que ocorria antes com o valor fixo `330` quando a velocidade chegava a 330

--- a/src/main/java/br/f1mane/entidades/Piloto.java
+++ b/src/main/java/br/f1mane/entidades/Piloto.java
@@ -31,6 +31,10 @@ public class Piloto implements Serializable, PilotoSuave {
     public static final String NORMAL = "NORMAL";
     public static final String LENTO = "LENTO";
     public static final int METADE_CARRO = 20;
+    /** Piso da faixa de oscilação da velocidade no limite máximo (km/h). */
+    public static final int TETO_VELOCIDADE_MIN = 370;
+    /** Teto absoluto de velocidade — nunca ultrapassado (km/h). */
+    public static final int TETO_VELOCIDADE_MAX = 375;
     private int id;
     private Carro carro = new Carro();
     private String nome;
@@ -154,6 +158,17 @@ public class Piloto implements Serializable, PilotoSuave {
     private int velocidade;
     @JsonIgnore
     private int velocidadeAnterior;
+    @JsonIgnore
+    private int velocidadeTetoOscilacao = TETO_VELOCIDADE_MIN;
+    @JsonIgnore
+    private boolean velocidadeTetoSubindo = true;
+    /** Estado da rampa artificial de reta sustentada — só afeta velocidadeExibir, nunca velocidade (ver calculaVelocidadeExibir). */
+    @JsonIgnore
+    private long tempoContinuoNaRetaMs;
+    @JsonIgnore
+    private int velocidadeExibirTetoOscilacao = TETO_VELOCIDADE_MIN;
+    @JsonIgnore
+    private boolean velocidadeExibirTetoSubindo = true;
     @JsonIgnore
     private transient String setUpIncial;
     @JsonIgnore
@@ -1304,6 +1319,26 @@ public class Piloto implements Serializable, PilotoSuave {
     }
 
     private int calculoVelocidade(double ganho) {
+        int distanciaKm = controleJogo.getCircuito().getDistanciaKm();
+        int velocidadeCalculada = (distanciaKm != 0) ? calculoVelocidadeReal(ganho, distanciaKm)
+                : calculoVelocidadeFallback(ganho);
+        return aplicaTetoVelocidade(velocidadeCalculada);
+    }
+
+    /**
+     * distanciaKm é gravado em metros (ver Circuito.getDistanciaKm()) — daí o
+     * 3600.0 (e não 3_600_000.0) já embutir a conversão metros -> km.
+     */
+    private int calculoVelocidadeReal(double ganho, int distanciaKm) {
+        int nosPorVolta = controleJogo.getNosDaPista().size();
+        long tempoCicloMs = controleJogo.tempoCicloCircuito();
+        if (nosPorVolta == 0 || tempoCicloMs == 0) {
+            return calculoVelocidadeFallback(ganho);
+        }
+        return Util.inteiro((ganho * distanciaKm * 3600.0) / (nosPorVolta * tempoCicloMs));
+    }
+
+    private int calculoVelocidadeFallback(double ganho) {
         int val = 290;
         double porcent = getCarro().getPorcentagemCombustivel() / 100.0;
         val += (21 - (porcent / 5.0));
@@ -1312,6 +1347,28 @@ public class Piloto implements Serializable, PilotoSuave {
             naReta = noAtual.verificaRetaOuLargada();
         }
         return Util.inteiro(((val * ganho * ((naReta) ? 1 : 0.7) / ganhoMax) + ganho * ((naReta) ? 1 : 0.7)));
+    }
+
+    private int aplicaTetoVelocidade(int velocidadeCalculada) {
+        if (velocidadeCalculada < TETO_VELOCIDADE_MIN) {
+            velocidadeTetoSubindo = true;
+            velocidadeTetoOscilacao = TETO_VELOCIDADE_MIN;
+            return velocidadeCalculada;
+        }
+        if (velocidadeTetoSubindo) {
+            velocidadeTetoOscilacao++;
+            if (velocidadeTetoOscilacao >= TETO_VELOCIDADE_MAX) {
+                velocidadeTetoOscilacao = TETO_VELOCIDADE_MAX;
+                velocidadeTetoSubindo = false;
+            }
+        } else {
+            velocidadeTetoOscilacao--;
+            if (velocidadeTetoOscilacao <= TETO_VELOCIDADE_MIN) {
+                velocidadeTetoOscilacao = TETO_VELOCIDADE_MIN;
+                velocidadeTetoSubindo = true;
+            }
+        }
+        return velocidadeTetoOscilacao;
     }
 
     public void processaColisao() {
@@ -3692,9 +3749,25 @@ public class Piloto implements Serializable, PilotoSuave {
         this.indiceTracado = indiceTracado;
     }
 
+    /** A partir de quanto tempo contínuo numa reta o efeito artificial de "esticar até o teto" entra em ação. */
+    private static final long LIMIAR_RETA_SUSTENTADA_MS = 3000;
+    /** Incremento artificial de velocidade exibida por ciclo, uma vez na reta sustentada (ignora a velocidade real). */
+    private static final int INCREMENTO_VELOCIDADE_RETA_SUSTENTADA = 2;
+    /** Acima disso, o incremento da reta sustentada fica mais tênue (sobe mais devagar). */
+    private static final int LIMIAR_VELOCIDADE_INCREMENTO_TENUE = 300;
+    /** Acima disso, fica ainda mais tênue — só um incremento a cada poucos ciclos, pra o teto só ser alcançado em retas bem longas. */
+    private static final int LIMIAR_VELOCIDADE_INCREMENTO_MUITO_TENUE = 340;
+    private static final int CICLOS_POR_INCREMENTO_MUITO_TENUE = 3;
+
     public void calculaVelocidadeExibir() {
         if (controleJogo.isJogoPausado()) {
             setVelocidadeExibir(0);
+            return;
+        }
+        atualizaTempoContinuoNaReta();
+        boolean naZonaFrenagem = noAtual != null && controleJogo.isNoZonaFrenagem(noAtual);
+        if (tempoContinuoNaRetaMs >= LIMIAR_RETA_SUSTENTADA_MS && !naZonaFrenagem) {
+            aplicaRetaSustentadaNaVelocidadeExibir();
             return;
         }
         int incAcell = 6;
@@ -3740,6 +3813,79 @@ public class Piloto implements Serializable, PilotoSuave {
         }
         int velocidade = (controleJogo.isSafetyCarNaPista() ? getVelocidadeExibir() / 2 : getVelocidadeExibir());
         setVelocidadeExibir(velocidade);
+    }
+
+    /**
+     * Zera a contagem assim que o nó atual deixa de ser reta/largada, ou o
+     * piloto está no traçado de fuga (4/5 — mesmo problema resolvido em
+     * PilotoGanhoTracadoDeFugaTest: o nó da pista principal não muda de tipo
+     * só por o piloto estar fisicamente na escapada).
+     */
+    private void atualizaTempoContinuoNaReta() {
+        boolean noTracadoDeFuga = getTracado() == 4 || getTracado() == 5;
+        boolean emRetaContinua = noAtual != null && noAtual.verificaRetaOuLargada() && !noTracadoDeFuga;
+        if (emRetaContinua) {
+            tempoContinuoNaRetaMs += controleJogo.tempoCicloCircuito();
+        } else {
+            tempoContinuoNaRetaMs = 0;
+        }
+    }
+
+    /**
+     * Efeito artificial, só no valor exibido: depois de
+     * LIMIAR_RETA_SUSTENTADA_MS numa reta contínua, ignora a velocidade real
+     * (velocidade/ganho) e faz velocidadeExibir subir aos poucos até o teto
+     * (370-375), simulando o carro esticando a reta até a velocidade máxima.
+     * velocidade (o valor real, usado por física/rede/efeitos) não é tocado
+     * — sai desse modo assim que o nó muda pra curva/escapada (ver
+     * atualizaTempoContinuoNaReta) ou entra na zona de frenagem
+     * (controleJogo.isNoZonaFrenagem — ver chamada em calculaVelocidadeExibir),
+     * voltando à suavização normal em direção à velocidade real (que já cai
+     * naturalmente ao frear). O incremento em si fica mais tênue conforme
+     * velocidadeExibir sobe (ver calculaIncrementoRetaSustentada), então o
+     * teto só é alcançado de fato em retas bem longas.
+     */
+    private void aplicaRetaSustentadaNaVelocidadeExibir() {
+        int candidato = getVelocidadeExibir() + calculaIncrementoRetaSustentada();
+        if (candidato < TETO_VELOCIDADE_MIN) {
+            velocidadeExibirTetoSubindo = true;
+            velocidadeExibirTetoOscilacao = TETO_VELOCIDADE_MIN;
+        } else if (velocidadeExibirTetoSubindo) {
+            velocidadeExibirTetoOscilacao++;
+            if (velocidadeExibirTetoOscilacao >= TETO_VELOCIDADE_MAX) {
+                velocidadeExibirTetoOscilacao = TETO_VELOCIDADE_MAX;
+                velocidadeExibirTetoSubindo = false;
+            }
+            candidato = velocidadeExibirTetoOscilacao;
+        } else {
+            velocidadeExibirTetoOscilacao--;
+            if (velocidadeExibirTetoOscilacao <= TETO_VELOCIDADE_MIN) {
+                velocidadeExibirTetoOscilacao = TETO_VELOCIDADE_MIN;
+                velocidadeExibirTetoSubindo = true;
+            }
+            candidato = velocidadeExibirTetoOscilacao;
+        }
+        setVelocidadeExibir(controleJogo.isSafetyCarNaPista() ? candidato / 2 : candidato);
+    }
+
+    /**
+     * Quanto maior velocidadeExibir, mais tênue o incremento da reta
+     * sustentada: abaixo de LIMIAR_VELOCIDADE_INCREMENTO_TENUE (300),
+     * incremento cheio a cada ciclo; dali até LIMIAR_VELOCIDADE_INCREMENTO_MUITO_TENUE
+     * (340), metade; a partir de 340, só 1 a cada CICLOS_POR_INCREMENTO_MUITO_TENUE
+     * ciclos (usando tempoContinuoNaRetaMs como relógio, sem precisar de mais
+     * um campo de estado) — o teto só é alcançado de fato em retas bem longas.
+     */
+    private int calculaIncrementoRetaSustentada() {
+        int velocidadeAtual = getVelocidadeExibir();
+        if (velocidadeAtual < LIMIAR_VELOCIDADE_INCREMENTO_TENUE) {
+            return INCREMENTO_VELOCIDADE_RETA_SUSTENTADA;
+        }
+        if (velocidadeAtual < LIMIAR_VELOCIDADE_INCREMENTO_MUITO_TENUE) {
+            return 1;
+        }
+        long ciclosNaReta = tempoContinuoNaRetaMs / controleJogo.tempoCicloCircuito();
+        return (ciclosNaReta % CICLOS_POR_INCREMENTO_MUITO_TENUE == 0) ? 1 : 0;
     }
 
     public boolean verificaColisaoAoMudarDeTracado(int pos) {

--- a/src/main/java/br/f1mane/visao/PainelCircuito.java
+++ b/src/main/java/br/f1mane/visao/PainelCircuito.java
@@ -5087,7 +5087,7 @@ public class PainelCircuito {
         g2d.setColor(transpMenus);
         g2d.fillRoundRect(limitesViewPort.x + pointDesenhaVelo.x, limitesViewPort.y + pointDesenhaVelo.y + 35, 160, 35,
                 0, 0);
-        Color corVelocidade = OcilaCor.porcentVermelho100Verde0((100 * velocidade / 330));
+        Color corVelocidade = OcilaCor.porcentVermelho100Verde0((100 * velocidade / Piloto.TETO_VELOCIDADE_MAX));
         g2d.setStroke(trilhoMiniPista);
 
         if (controleJogo.isSafetyCarNaPista()) {

--- a/src/test/java/br/f1mane/entidades/PilotoCalculoVelocidadeTest.java
+++ b/src/test/java/br/f1mane/entidades/PilotoCalculoVelocidadeTest.java
@@ -1,0 +1,344 @@
+package br.f1mane.entidades;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.awt.Point;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import br.f1mane.controles.InterfaceJogo;
+
+/**
+ * Cobre o novo cálculo de velocidade real (km/h a partir do avanço de índice
+ * relativo ao tamanho do circuito e à distância real em km), o fallback pra
+ * circuitos sem distanciaKm informado, o teto com oscilação (370-375), e o
+ * efeito artificial de reta sustentada — que sobe gradualmente até o teto
+ * depois de 3s contínuos numa reta, mas só no valor exibido
+ * (velocidadeExibir/calculaVelocidadeExibir), nunca na velocidade real
+ * (velocidade/calculoVelocidade), usada por física, rede e efeitos visuais
+ * (chuva).
+ */
+class PilotoCalculoVelocidadeTest {
+
+    private InterfaceJogo controleJogo;
+
+    private Piloto criarPiloto(int distanciaKm, int nosPorVolta, long cicloMs) {
+        controleJogo = mock(InterfaceJogo.class);
+        GameRandom random = new GameRandom(1);
+        when(controleJogo.getRandom()).thenReturn(random);
+        when(controleJogo.isChovendo()).thenReturn(false);
+        when(controleJogo.isErs()).thenReturn(false);
+
+        Circuito circuito = new Circuito();
+        circuito.setDistanciaKm(distanciaKm);
+        when(controleJogo.getCircuito()).thenReturn(circuito);
+
+        List<No> nos = new ArrayList<>(Collections.nCopies(nosPorVolta, new No()));
+        when(controleJogo.getNosDaPista()).thenReturn(nos);
+        when(controleJogo.tempoCicloCircuito()).thenReturn(cicloMs);
+
+        Piloto piloto = new Piloto();
+        piloto.setControleJogo(controleJogo);
+        Carro carro = new Carro();
+        carro.setPiloto(piloto);
+        carro.setPotencia(0);
+        carro.setAerodinamica(0);
+        carro.setFreios(0);
+        carro.setPorcentagemCombustivel(50);
+        piloto.setCarro(carro);
+        piloto.setHabilidade(1000);
+
+        No no = new No();
+        no.setIndex(500);
+        no.setPoint(new Point(500, 100));
+        no.setTipo(No.RETA);
+        piloto.setNoAtual(no);
+        piloto.setAtivarDRS(false);
+        piloto.setAtivarErs(false);
+        piloto.setFreiandoReta(false);
+        return piloto;
+    }
+
+    private void setGanhoMax(Piloto piloto, double ganhoMax) throws Exception {
+        Field f = Piloto.class.getDeclaredField("ganhoMax");
+        f.setAccessible(true);
+        f.set(piloto, ganhoMax);
+    }
+
+    /**
+     * Pula direto pro estado "reta sustentada ativa" (equivalente a já ter passado
+     * dos 3s continuos em reta), sem precisar rodar os ciclos de aquecimento
+     * (que disparariam a suavização normal e mudariam velocidadeExibir de forma
+     * imprevisível antes do ponto que o teste quer observar).
+     */
+    private void ativarRetaSustentadaDireto(Piloto piloto) throws Exception {
+        Field f = Piloto.class.getDeclaredField("tempoContinuoNaRetaMs");
+        f.setAccessible(true);
+        f.set(piloto, 3000L);
+    }
+
+    /** Espelha o que processaNovoIndex() faz de verdade: setVelocidade(calculoVelocidade(ganho)). */
+    private int chamarCalculoVelocidade(Piloto piloto, double ganho) throws Exception {
+        Method m = Piloto.class.getDeclaredMethod("calculoVelocidade", double.class);
+        m.setAccessible(true);
+        int velocidade = (int) m.invoke(piloto, ganho);
+        piloto.setVelocidade(velocidade);
+        return velocidade;
+    }
+
+    private int chamarCalculoVelocidadeReal(Piloto piloto, double ganho, int distanciaKm) throws Exception {
+        Method m = Piloto.class.getDeclaredMethod("calculoVelocidadeReal", double.class, int.class);
+        m.setAccessible(true);
+        return (int) m.invoke(piloto, ganho, distanciaKm);
+    }
+
+    @Test
+    void formulaReal_usaGanho_distanciaKm_nosPorVolta_e_tempoCiclo() throws Exception {
+        // ganho=10, distanciaKm=1000m, nosPorVolta=100, ciclo=100ms
+        // -> (10 * 1000 * 3600.0) / (100 * 100) = 3600
+        Piloto piloto = criarPiloto(1000, 100, 100L);
+
+        int velocidade = chamarCalculoVelocidadeReal(piloto, 10, 1000);
+
+        assertEquals(3600, velocidade);
+    }
+
+    @Test
+    void circuitosComDistanciasDiferentes_produzemVelocidadesProporcionais() throws Exception {
+        Piloto piloto1km = criarPiloto(1000, 100, 100L);
+        Piloto piloto2km = criarPiloto(2000, 100, 100L);
+
+        int velocidade1 = chamarCalculoVelocidadeReal(piloto1km, 10, 1000);
+        int velocidade2 = chamarCalculoVelocidadeReal(piloto2km, 10, 2000);
+
+        assertEquals(velocidade1 * 2, velocidade2,
+                "circuito com o dobro da distância deveria produzir o dobro da velocidade, pro mesmo ganho");
+    }
+
+    @Test
+    void distanciaKmZero_mantemFormulaAntiga_semAtingirOTeto() throws Exception {
+        Piloto piloto = criarPiloto(0, 100, 160L);
+        setGanhoMax(piloto, 40.0);
+        double ganho = 20.0;
+
+        int val = 290;
+        val += (21 - (50 / 100.0 / 5.0));
+        double esperado = (val * ganho * 0.7 / 40.0) + ganho * 0.7;
+
+        int velocidade = chamarCalculoVelocidade(piloto, ganho);
+
+        assertEquals(Math.round(esperado), velocidade,
+                "sem distanciaKm, o resultado deve bater com a fórmula antiga (fallback), abaixo do teto");
+    }
+
+    @Test
+    void velocidadeCalculada_acimaDoTeto_nuncaUltrapassaTetoMaximo() throws Exception {
+        // distanciaKm/nosPorVolta/ciclo escolhidos pra forçar um valor bem acima do teto
+        Piloto piloto = criarPiloto(5000, 10, 100L);
+
+        for (int i = 0; i < 20; i++) {
+            int velocidade = chamarCalculoVelocidade(piloto, 30);
+            assertTrue(velocidade <= Piloto.TETO_VELOCIDADE_MAX,
+                    "velocidade nao deveria ultrapassar o teto maximo: " + velocidade);
+            assertTrue(velocidade >= Piloto.TETO_VELOCIDADE_MIN,
+                    "velocidade no teto nao deveria cair abaixo do piso da oscilacao: " + velocidade);
+        }
+    }
+
+    @Test
+    void velocidadeNoTeto_oscilaEntreMinEMax_aoLongoDeCiclosConsecutivos() throws Exception {
+        Piloto piloto = criarPiloto(5000, 10, 100L);
+
+        int min = Integer.MAX_VALUE;
+        int max = Integer.MIN_VALUE;
+        for (int i = 0; i < 20; i++) {
+            int velocidade = chamarCalculoVelocidade(piloto, 30);
+            min = Math.min(min, velocidade);
+            max = Math.max(max, velocidade);
+        }
+
+        assertEquals(Piloto.TETO_VELOCIDADE_MIN, min);
+        assertEquals(Piloto.TETO_VELOCIDADE_MAX, max);
+    }
+
+    @Test
+    void doisPilotosNoTeto_oscilamDeFormaIndependente() throws Exception {
+        Piloto piloto1 = criarPiloto(5000, 10, 100L);
+        Piloto piloto2 = criarPiloto(5000, 10, 100L);
+
+        // avanca piloto1 sozinho por alguns ciclos antes de comecar a avancar piloto2 junto,
+        // pra garantir que as duas oscilacoes fiquem fora de fase uma da outra
+        for (int i = 0; i < 3; i++) {
+            chamarCalculoVelocidade(piloto1, 30);
+        }
+
+        boolean encontrouDiferenca = false;
+        for (int i = 0; i < 20; i++) {
+            int velocidade1 = chamarCalculoVelocidade(piloto1, 30);
+            int velocidade2 = chamarCalculoVelocidade(piloto2, 30);
+            if (velocidade1 != velocidade2) {
+                encontrouDiferenca = true;
+                break;
+            }
+        }
+
+        assertTrue(encontrouDiferenca,
+                "pilotos que atingem o teto em momentos diferentes deveriam oscilar fora de fase um do outro");
+    }
+
+    @Test
+    void retaSustentada_apos3Segundos_ignoraVelocidadeRealESobeGradualmenteSoNoValorExibido() throws Exception {
+        Piloto piloto = criarPiloto(0, 100, 1000L); // ciclo de 1000ms: cada chamada = 1 segundo em reta
+        piloto.setVelocidade(0); // velocidade real fica parada em 0 o tempo todo (nunca mais setada neste teste)
+        piloto.setVelocidadeExibir(300);
+
+        piloto.calculaVelocidadeExibir(); // 1s continuo em reta
+        int v1 = piloto.getVelocidadeExibir();
+        piloto.calculaVelocidadeExibir(); // 2s continuo em reta
+        int v2 = piloto.getVelocidadeExibir();
+        piloto.calculaVelocidadeExibir(); // 3s continuo -> reta sustentada ativa
+        int v3 = piloto.getVelocidadeExibir();
+        piloto.calculaVelocidadeExibir(); // 4s continuo -> continua subindo
+        int v4 = piloto.getVelocidadeExibir();
+
+        assertTrue(v1 < 300 && v2 < v1,
+                "abaixo dos 3s, velocidadeExibir deveria seguir a suavizacao normal em direcao a velocidade real (0), ou seja, caindo");
+        assertEquals(v2 + 2, v3,
+                "ao cruzar 3s continuos em reta, velocidadeExibir deveria subir +2 ignorando a velocidade real (0)");
+        assertEquals(v3 + 2, v4, "uma vez em reta sustentada, cada ciclo soma +2 no valor exibido");
+        assertEquals(0, piloto.getVelocidade(),
+                "a velocidade real (usada por fisica/rede/efeitos) nunca deveria ser tocada pelo efeito de reta sustentada");
+    }
+
+    @Test
+    void saindoDaReta_voltaImediatamenteARegraNormalNoValorExibido() throws Exception {
+        Piloto piloto = criarPiloto(0, 100, 1000L);
+        piloto.setVelocidade(0);
+        piloto.setVelocidadeExibir(300);
+
+        piloto.calculaVelocidadeExibir(); // 1s
+        piloto.calculaVelocidadeExibir(); // 2s
+        piloto.calculaVelocidadeExibir(); // 3s -> reta sustentada ativa
+        int vEmRampa = piloto.getVelocidadeExibir();
+
+        No curva = new No();
+        curva.setIndex(600);
+        curva.setPoint(new Point(600, 100));
+        curva.setTipo(No.CURVA_ALTA);
+        piloto.setNoAtual(curva);
+
+        piloto.calculaVelocidadeExibir();
+        int vAposCurva = piloto.getVelocidadeExibir();
+
+        assertTrue(vAposCurva < vEmRampa,
+                "ao entrar numa curva, velocidadeExibir deveria voltar a cair em direcao a velocidade real (0), nao continuar subindo +2");
+    }
+
+    @Test
+    void tracadoDeFuga_nuncaAtivaRetaSustentada_mesmoComNoMarcadoComoReta() throws Exception {
+        Piloto piloto = criarPiloto(0, 100, 1000L);
+        piloto.setTracado(4); // traçado de fuga (escapada)
+        piloto.setVelocidade(0);
+        piloto.setVelocidadeExibir(300);
+
+        piloto.calculaVelocidadeExibir();
+        int v1 = piloto.getVelocidadeExibir();
+        piloto.calculaVelocidadeExibir();
+        piloto.calculaVelocidadeExibir();
+        piloto.calculaVelocidadeExibir(); // 4o ciclo "no tipo reta", mas sempre na escapada
+        int v4 = piloto.getVelocidadeExibir();
+
+        assertEquals(v1 - 9, v4,
+                "no traçado de fuga (4/5), a reta sustentada nunca deveria ativar: velocidadeExibir so cai (-3/ciclo) em direcao a velocidade real, nunca sobe +2");
+    }
+
+    @Test
+    void zonaDeFrenagem_desativaRetaSustentada() throws Exception {
+        Piloto piloto = criarPiloto(0, 100, 1000L);
+        when(controleJogo.isNoZonaFrenagem(any())).thenReturn(true);
+        piloto.setVelocidade(0);
+        piloto.setVelocidadeExibir(300);
+
+        piloto.calculaVelocidadeExibir();
+        int v1 = piloto.getVelocidadeExibir();
+        piloto.calculaVelocidadeExibir();
+        piloto.calculaVelocidadeExibir();
+        piloto.calculaVelocidadeExibir(); // 4s continuos em reta, mas sempre na zona de frenagem
+        int v4 = piloto.getVelocidadeExibir();
+
+        assertEquals(v1 - 9, v4,
+                "na zona de frenagem, a reta sustentada nunca deveria ativar, mesmo com 4s continuos em reta: velocidadeExibir so cai (-3/ciclo)");
+    }
+
+    @Test
+    void saindoDaZonaDeFrenagem_aRetaSustentadaAtivaImediatamenteSeOContadorJaPassouDoLimiar() throws Exception {
+        Piloto piloto = criarPiloto(0, 100, 1000L);
+        when(controleJogo.isNoZonaFrenagem(any())).thenReturn(true, true, true, false);
+        piloto.setVelocidade(0);
+        piloto.setVelocidadeExibir(300);
+
+        piloto.calculaVelocidadeExibir(); // 1s, na zona de frenagem
+        piloto.calculaVelocidadeExibir(); // 2s, na zona de frenagem
+        piloto.calculaVelocidadeExibir(); // 3s, ainda na zona de frenagem -> nao ativa
+        int v3 = piloto.getVelocidadeExibir();
+        piloto.calculaVelocidadeExibir(); // 4s, fora da zona de frenagem -> ativa, contador ja acima do limiar
+        int v4 = piloto.getVelocidadeExibir();
+
+        assertEquals(v3 + 2, v4,
+                "ao sair da zona de frenagem com o contador de reta continua ja acima do limiar, a rampa deveria ativar no mesmo ciclo");
+    }
+
+    @Test
+    void incrementoContinuaCheioAbaixoDe300() throws Exception {
+        Piloto piloto = criarPiloto(0, 100, 1000L);
+        ativarRetaSustentadaDireto(piloto);
+        piloto.setVelocidade(0);
+        piloto.setVelocidadeExibir(250);
+
+        piloto.calculaVelocidadeExibir();
+
+        assertEquals(252, piloto.getVelocidadeExibir(),
+                "abaixo de 300, o incremento da reta sustentada continua cheio (2 por ciclo)");
+    }
+
+    @Test
+    void incrementoCaiParaUmEntre300e340() throws Exception {
+        Piloto piloto = criarPiloto(0, 100, 1000L);
+        ativarRetaSustentadaDireto(piloto);
+        piloto.setVelocidade(0);
+        piloto.setVelocidadeExibir(320);
+
+        piloto.calculaVelocidadeExibir();
+
+        assertEquals(321, piloto.getVelocidadeExibir(),
+                "entre 300 e 340, o incremento da reta sustentada cai pra 1 por ciclo (metade do normal)");
+    }
+
+    @Test
+    void incrementoFicaMuitoTenueAcimaDe340_soUmACadaTresCiclos() throws Exception {
+        Piloto piloto = criarPiloto(0, 100, 1000L);
+        ativarRetaSustentadaDireto(piloto);
+        piloto.setVelocidade(0);
+        piloto.setVelocidadeExibir(345);
+
+        piloto.calculaVelocidadeExibir();
+        int v1 = piloto.getVelocidadeExibir();
+        piloto.calculaVelocidadeExibir();
+        int v2 = piloto.getVelocidadeExibir();
+        piloto.calculaVelocidadeExibir();
+        int v3 = piloto.getVelocidadeExibir();
+
+        assertEquals(345, v1, "acima de 340, a maioria dos ciclos nao incrementa velocidadeExibir");
+        assertEquals(345, v2, "acima de 340, a maioria dos ciclos nao incrementa velocidadeExibir");
+        assertEquals(346, v3, "a cada CICLOS_POR_INCREMENTO_MUITO_TENUE (3) ciclos, velocidadeExibir sobe 1 — o teto so e alcancado em retas bem longas");
+    }
+}


### PR DESCRIPTION
Substitui a formula de velocidade baseada em constantes arbitrarias por um calculo real (avanco de indice x extensao do circuito / ciclo), com teto de 370-375 km/h que oscila em vez de travar, e um efeito artificial de reta sustentada que so afeta o valor exibido no velocimetro (nunca a velocidade real usada por rede/efeitos), desativado em zona de frenagem e cada vez mais tenue acima de 300 km/h.