### PR TITLE
Adia desenho de objetos no scroll do editor e permite Delete na lista

### DIFF
--- a/openspec/changes/archive/2026-07-13-editor-delay-scroll-delete-lista/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-13-editor-delay-scroll-delete-lista/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-13

--- a/openspec/changes/archive/2026-07-13-editor-delay-scroll-delete-lista/design.md
+++ b/openspec/changes/archive/2026-07-13-editor-delay-scroll-delete-lista/design.md
@@ -1,0 +1,48 @@
+## Context
+
+`MainPanelEditor` (canvas do editor de circuitos, `src/main/java/br/f1mane/editor/MainPanelEditor.java`) é um `JPanel` sem thread de render próprio: tudo é desenhado em `paintComponent()`, disparado sincronamente na EDT sempre que `repaint()` é chamado. O pan por seta (`esquerda()/direita()/cima()/baixo()`, linhas ~1590-1653) move a `viewPosition` do `JScrollPane` em passos de 40px e chama `repaint()` a cada passo — segurar uma seta gera dezenas de repaints completos por segundo, cada um percorrendo `desenhaObjetosNivel` para todos os objetos visíveis (já com o corte de viewport de `editor-viewport-culling`, mas ainda assim custoso em circuitos densos).
+
+Na lista única de objetos (`FormularioListaObjetos`, feature de `editor-lista-objetos-filtro-tipo`), o `JList list` não tem `KeyListener` próprio. A tecla Delete só é tratada pelo `KeyAdapter` global de `EditorCircuitos`, que chama `MainPanelEditor.apagarObjetoSelecionado()` — método que opera sobre o campo `objetoPista` (setado por clique no canvas), não sobre a seleção da `JList`. Precedente já existe: `pistaJList`/`boxJList` (listas de nós) têm cada uma seu próprio `KeyAdapter` com tratamento de `VK_DELETE`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Reduzir a quantidade de repaints completos da camada de objetos durante o pan por seta, sem quebrar o movimento visual da viewport em si.
+- Redesenhar os objetos uma única vez, 0,5 segundos após o usuário parar de pressionar/segurar as setas.
+- Permitir remover o objeto selecionado na `JList` de `FormularioListaObjetos` pressionando Delete com foco nela, reaproveitando a lógica já existente do botão "Remover".
+
+**Non-Goals:**
+- Não altera o comportamento de pan em si (distância por passo, teclas Alt/Shift para mover/redimensionar objeto selecionado).
+- Não altera `apagarObjetoSelecionado()` nem o fluxo de Delete via clique no canvas (`objetoPista`) — o novo `KeyListener` da lista é um caminho adicional, não uma substituição.
+- Não introduz threads de render em background; o debounce usa `javax.swing.Timer`, que já dispara na EDT.
+
+## Decisions
+
+**O debounce protege só a iteração sobre os objetos, dentro de `paintComponent` — não o `repaint()` em si.**
+Uma primeira versão desta feature pulava a própria chamada de `repaint()` durante o pan (só chamando `timer.restart()`), e isso quebrou `desenhaInfo()`/`desenhaControles()`: esses dois métodos desenham overlays (painéis de HUD com texto/atalhos) fixos ao canto da viewport, recalculando sua posição a cada chamada a partir de `limitesViewPort()` — ou seja, ao contrário do resto do canvas (fundo, traçado, objetos), eles NÃO são conteúdo estático em coordenadas de circuito. O scroll da `JViewport` usa blit (`copyArea`) para deslocar os pixels já pintados e só pede repaint automático da faixa recém-exposta; para conteúdo estático isso é correto (a mesma pista, no mesmo lugar, só a janela visível mudou). Mas para os overlays pinados à viewport, o blit arrasta a posição "congelada" do frame anterior junto com o resto do canvas, em vez de recalculá-la — um artefato visual visível sobre o fundo/pista enquanto o usuário segura a seta.
+A correção: `repaint()` volta a ser chamado a cada passo de pan, normalmente (via `iniciarOuEstenderDebounceRedesenhoPosScroll()`), então `paintComponent` roda a cada passo e os overlays fixos à viewport são sempre recalculados corretamente. O que fica condicionado ao debounce é só a iteração sobre `todosObjetos()`/`niveisDesenhoOrdenados()`/`desenhaObjetosNivel()` dentro de `paintComponent` — isolada em `deveDesenharObjetos()` (`!timerRedesenhoObjetosPosScroll.isRunning()`) — que é o custo que efetivamente motivou o pedido original ("percorrer todos os objetos visíveis" em circuitos densos). Enquanto um gesto de pan está em andamento (timer rodando), essa camada simplesmente não é desenhada nesse frame (não fica "parada" da posição anterior — como todo o resto do frame é redesenhado do zero a cada `paintComponent`, os objetos ficam ausentes até o debounce disparar); ao soltar a seta, 0,5s depois o timer dispara, chama `repaint()`, e como não há mais gesto em andamento `deveDesenharObjetos()` volta a `true`.
+- Alternativa considerada (versão anterior deste design): pular o próprio `repaint()` durante o pan, com um repaint imediato só no primeiro passo do gesto — rejeitada porque não resolve o artefato do HUD pinado à viewport nos passos seguintes do mesmo gesto (só no primeiro).
+- Alternativa considerada: mover `desenhaInfo`/`desenhaControles` pra fora do `paintComponent` do canvas, como componentes Swing reais posicionados sobre o `JViewport` (ex.: `scrollPane.setCorner(...)` ou um glass pane) — resolveria o artefato "pela raiz" (deixariam de fazer parte do raster afetado pelo blit-scroll), mas é um refactor bem maior; não adotado nesta mudança porque manter `repaint()` a cada passo (barato, já que a parte cara — os objetos — está protegida) já resolve o artefato relatado sem mexer na estrutura de desenho existente.
+- Alternativa considerada: usar `Thread.sleep`/`ScheduledExecutorService` para o debounce — rejeitada porque exigiria sincronizar de volta com a EDT para chamar `repaint()`, sem ganho sobre `javax.swing.Timer`, que já roda na EDT e é o padrão Swing para isso.
+
+**Escopo do debounce: apenas a iteração sobre objetos originada do pan por seta (`esquerda/direita/cima/baixo`), não outras causas de redesenho.**
+Outras chamadas de `repaint()` no arquivo (drag de mouse, seleção na lista, criação/edição de objeto) continuam fora do controle de `deveDesenharObjetos()` no sentido de que não reiniciam o timer — mas, como a checagem do timer está dentro de `paintComponent`, se uma dessas ações disparar um repaint enquanto o timer de um pan recente ainda está rodando, os objetos também ficariam temporariamente ausentes nesse frame. Na prática isso é um caso raro (editar/arrastar um objeto enquanto ainda se está no meio de um gesto de pan) e não afeta a resposta ao clique/drag em si, só adia por até 0,5s o redesenho visual dos demais objetos nesse cenário combinado — aceito como trade-off menor, não coberto por teste dedicado.
+
+**Delete na `JList` reaproveita a lógica do botão "Remover", não `apagarObjetoSelecionado()`.**
+O novo `KeyAdapter` em `FormularioListaObjetos.list` (em `iniciarComponentes()`) trata `VK_DELETE` chamando a mesma lógica do `ActionListener` do botão "Remover" (`defaultListModelOP.remove(sel); atualizarCircuito();`), extraída para um método privado reutilizável. Isso mantém consistência com o padrão já usado em `pistaJList`/`boxJList` e evita duplicar/alterar `MainPanelEditor.apagarObjetoSelecionado()`, que continua servindo exclusivamente o fluxo de seleção por clique no canvas.
+
+## Risks / Trade-offs
+
+- [Objetos ficam completamente ausentes do canvas durante um gesto de pan (em vez de mostrar sua posição anterior), reaparecendo só 0,5s depois de parar] → Mitigação: é o comportamento aceito para esta mudança — o objetivo original era reduzir custo durante o scroll, e ausência total (com o resto do frame — fundo, traçado, HUD — sempre correto) é mais barata e visualmente mais limpa do que manter objetos desenhados na posição errada.
+- [`repaint()` a cada passo de pan reintroduz o custo do resto do `paintComponent` — fundo, traçado, HUD — que a versão original desta mudança tentava eliminar por completo] → Mitigação: esse custo é o que já existia antes desta feature inteira (pré-existente, não é o alvo do pedido original); o pedido era especificamente sobre o custo de "percorrer todos os objetos visíveis", que é o que de fato fica protegido pelo debounce.
+- [Editar/arrastar um objeto com o mouse enquanto o timer de um pan recente ainda está rodando (gesto combinado raro) deixa a camada de objetos ausente durante esse intervalo, mesmo fora do pan em si] → Mitigação: trade-off aceito, não coberto por teste dedicado — cenário raro (usuário solta a seta e imediatamente clica um objeto antes dos 0,5s), sem perda de dados, só um atraso visual adicional.
+- [Timer de 0,5s compartilhado entre os quatro métodos de pan pode não disparar se o usuário alternar rapidamente entre setas diferentes sem pausa] → Mitigação: é o comportamento desejado — qualquer novo passo de pan (em qualquer direção) reinicia o timer, então o redesenho dos objetos só ocorre 0,5s após o *último* movimento, independente da direção.
+- [Testes existentes de `MainPanelEditor` que chamam `esquerda()/direita()/cima()/baixo()` e verificam `repaint()` imediato podem quebrar] → Mitigação: ajustados para verificar `repaint()` a cada passo e o estado de `deveDesenharObjetos()`/timer, em vez de assumir que o redesenho da camada de objetos é imediato (ver `MainPanelEditorScrollDebounceTest`).
+
+## Migration Plan
+
+Mudança aditiva e local ao editor (ferramenta de desenvolvimento, não afeta runtime do jogo/servidor). Sem dado persistido, sem rollback especial: reverter o commit é suficiente caso necessário.
+
+## Open Questions
+
+Nenhuma em aberto — o requisito de negócio (0,5 segundos, gatilho por parada do scroll) foi confirmado diretamente pelo usuário.

--- a/openspec/changes/archive/2026-07-13-editor-delay-scroll-delete-lista/proposal.md
+++ b/openspec/changes/archive/2026-07-13-editor-delay-scroll-delete-lista/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+Movimentar a tela do editor de circuitos pelas setas do teclado redesenha todos os objetos do circuito a cada passo, o que degrada a performance em circuitos com muitos objetos. Além disso, ao selecionar um objeto na lista única do editor (`FormularioListaObjetos`), a tecla Delete não faz nada — a remoção via teclado só funciona quando o objeto foi clicado no canvas, obrigando o usuário a usar o botão "Remover" na lista.
+
+## What Changes
+
+- Ao mover a tela pelas setas do teclado (pan via `MainPanelEditor.esquerda()/direita()/cima()/baixo()`), o redesenho completo dos objetos do circuito passa a ser adiado (debounce) por 0,5 segundos após o último movimento, em vez de redesenhar a cada passo de scroll.
+- Durante o período de scroll ativo (antes do debounce disparar), o canvas continua respondendo ao movimento da viewport, mas sem repintar a camada de objetos a cada passo.
+- Adiciona um `KeyListener` na `JList` de `FormularioListaObjetos` para a tecla Delete: com um objeto selecionado na lista, Delete remove esse objeto (mesma lógica do botão "Remover" já existente), sem exigir que o objeto também esteja selecionado via clique no canvas (`objetoPista`).
+
+## Capabilities
+
+### New Capabilities
+- `editor-scroll-atraso-desenho`: adia o redesenho dos objetos do circuito por 0,5 segundos após o usuário parar de mover a tela pelas setas do teclado, reduzindo repaints durante o scroll.
+
+### Modified Capabilities
+- `editor-lista-objetos-filtro-tipo`: a tecla Delete, com foco na lista única de objetos e um item selecionado, passa a remover o objeto selecionado (mesmo comportamento do botão "Remover").
+
+## Impact
+
+- `src/main/java/br/f1mane/editor/MainPanelEditor.java`: métodos `esquerda()`, `direita()`, `cima()`, `baixo()` (pan por seta) e o ponto de repaint da camada de objetos.
+- `src/main/java/br/f1mane/editor/FormularioListaObjetos.java`: `iniciarComponentes()` (onde o `JList list` é configurado) e reuso da lógica de remoção já usada pelo botão "Remover" (`atualizarCircuito()`).
+- Testes existentes que exercitam pan por seta e o filtro/lista de objetos (`MainPanelEditor*Test`, `FormularioListaObjetos*Test` se existirem) podem precisar de ajuste para o novo debounce.

--- a/openspec/changes/archive/2026-07-13-editor-delay-scroll-delete-lista/specs/editor-lista-objetos-filtro-tipo/spec.md
+++ b/openspec/changes/archive/2026-07-13-editor-delay-scroll-delete-lista/specs/editor-lista-objetos-filtro-tipo/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: Tecla Delete remove o objeto selecionado na lista única
+Com o foco na lista única de objetos (`FormularioListaObjetos`) e um item selecionado, pressionar a tecla Delete SHALL remover esse objeto, com o mesmo efeito do botão "Remover" já existente: o objeto é removido da coleção do `Circuito` correspondente ao seu tipo (`circuito.getObjetos()` ou `circuito.getObjetosCenario()`) e deixa de aparecer na lista e no desenho do circuito.
+
+#### Scenario: Delete com item selecionado remove o objeto
+- **WHEN** o usuário seleciona um objeto na lista única de objetos e pressiona a tecla Delete com o foco na lista
+- **THEN** o objeto selecionado é removido da coleção correspondente do `Circuito`, desaparece da lista única e deixa de ser desenhado no canvas
+
+#### Scenario: Delete sem seleção não tem efeito
+- **WHEN** o usuário pressiona a tecla Delete com o foco na lista única de objetos e nenhum item selecionado
+- **THEN** nenhum objeto é removido e a lista permanece inalterada
+
+#### Scenario: Delete na lista funciona mesmo sem seleção prévia no canvas
+- **WHEN** o usuário seleciona um objeto exclusivamente através da lista única (sem clicar nesse objeto no canvas) e pressiona Delete com o foco na lista
+- **THEN** o objeto é removido normalmente, independente do valor atual do campo de seleção usado pelo clique no canvas

--- a/openspec/changes/archive/2026-07-13-editor-delay-scroll-delete-lista/specs/editor-scroll-atraso-desenho/spec.md
+++ b/openspec/changes/archive/2026-07-13-editor-delay-scroll-delete-lista/specs/editor-scroll-atraso-desenho/spec.md
@@ -1,0 +1,28 @@
+## ADDED Requirements
+
+### Requirement: Redesenho dos objetos atrasado após pan por seta
+Ao mover a viewport do editor de circuitos pelas setas do teclado (sem modificadores, via `MainPanelEditor.esquerda()/direita()/cima()/baixo()`), o editor SHALL suspender o desenho da camada de objetos do circuito enquanto um passo de pan tiver ocorrido nos últimos 0,5 segundos, retomando o desenho dessa camada somente 0,5 segundos após o último passo de movimento. O restante do frame — cor de fundo, imagem de referência, traçado do circuito e os overlays fixos ao canto da viewport (painéis de informação/controles, posicionados a partir dos limites atuais da viewport) — SHALL continuar sendo redesenhado normalmente a cada passo de pan, sem esse atraso.
+
+#### Scenario: Um único passo de seta suspende o desenho dos objetos
+- **WHEN** o usuário pressiona uma seta de navegação uma única vez, movendo a viewport
+- **THEN** a camada de objetos do circuito não é desenhada nesse passo, e volta a ser desenhada somente 0,5 segundos depois, caso nenhum outro passo de pan ocorra nesse intervalo
+
+#### Scenario: Novos passos de pan reiniciam a contagem de 0,5 segundos
+- **WHEN** o usuário segura ou pressiona repetidamente as setas de navegação, gerando vários passos de pan em sequência com menos de 0,5 segundos entre eles
+- **THEN** a camada de objetos permanece sem ser desenhada durante essa sequência, voltando a ser desenhada uma única vez, 0,5 segundos após o último passo de pan
+
+#### Scenario: Direções diferentes de pan compartilham a mesma contagem
+- **WHEN** o usuário alterna entre setas de direções diferentes (por exemplo, direita e depois cima) sem pausa maior que 0,5 segundos entre os passos
+- **THEN** a suspensão do desenho dos objetos continua como uma única contagem contínua, sendo desfeita apenas 0,5 segundos após o último passo de pan em qualquer direção
+
+#### Scenario: Fundo, traçado e overlays fixos à viewport são redesenhados a cada passo, sem atraso
+- **WHEN** o usuário move a tela pelas setas, com a camada de objetos ainda suspensa pelo atraso
+- **THEN** a cor de fundo, a imagem de referência, o traçado do circuito e os overlays fixos ao canto da viewport são redesenhados corretamente a cada passo, refletindo a nova posição da viewport, sem esperar os 0,5 segundos
+
+#### Scenario: Overlays fixos à viewport não deixam artefato visual durante o pan
+- **WHEN** o usuário move a tela pelas setas em sequência (vários passos, com a camada de objetos suspensa)
+- **THEN** os overlays fixos ao canto da viewport (painéis de informação/controles) permanecem visualmente presos ao canto correto da área visível a cada passo, sem deixar cópias desatualizadas ou deslocadas sobre o fundo do circuito
+
+#### Scenario: Outras causas de redesenho não reiniciam a contagem de pan
+- **WHEN** ocorre um redesenho motivado por outra ação do editor que não seja o pan por seta (por exemplo, arrastar um objeto com o mouse, selecionar um item na lista de objetos, ou criar/editar um objeto)
+- **THEN** esse redesenho não reinicia nem altera a contagem de 0,5 segundos associada ao pan por seta

--- a/openspec/changes/archive/2026-07-13-editor-delay-scroll-delete-lista/tasks.md
+++ b/openspec/changes/archive/2026-07-13-editor-delay-scroll-delete-lista/tasks.md
@@ -1,0 +1,23 @@
+## 1. Atraso no redesenho dos objetos ao mover a tela pelas setas
+
+- [x] 1.1 Adicionar um campo `javax.swing.Timer` em `MainPanelEditor` (delay 500ms, `setRepeats(false)`) cujo `ActionListener` chama o `repaint()` que hoje é disparado a cada passo de pan.
+- [x] 1.2 Em `esquerda()`, `direita()`, `cima()` e `baixo()` (linhas ~1590-1653), manter a atualização imediata de `scrollPane.getViewport().setViewPosition(...)`, mas trocar a chamada de `repaint()` da camada de objetos por `timer.restart()`.
+- [x] 1.3 Garantir que o timer é compartilhado entre as quatro direções (uma única instância), de forma que alternar entre setas diferentes reinicie a mesma contagem de 0,5s em vez de disparar múltiplos timers concorrentes.
+- [x] 1.4 Conferir que outras chamadas de `repaint()` no arquivo (drag de objeto, seleção na lista, criação/edição de objeto, etc.) continuam chamando `repaint()` normalmente (não passam a reiniciar o timer de pan).
+- [x] 1.6 **(Revisado — ver 1.7)** Primeira tentativa: pular `repaint()` durante o pan, exceto no 1º passo do gesto. Abandonada: `desenhaInfo()`/`desenhaControles()` são overlays fixos ao canto da viewport (posição recalculada a cada frame a partir de `limitesViewPort()`), não conteúdo estático em coordenadas de circuito — pular `repaint()` nos passos seguintes do gesto deixava sua posição "presa" ao frame anterior, arrastada pelo blit-scroll da `JViewport` como um artefato visual sobre o fundo/pista.
+- [x] 1.7 Mover o adiamento pra dentro de `paintComponent`: `repaint()` volta a ser chamado a cada passo de pan (via `iniciarOuEstenderDebounceRedesenhoPosScroll()`, sempre), mantendo fundo/traçado/overlays fixos à viewport sempre corretos. Só a iteração sobre os objetos do circuito (`todosObjetos()`/`niveisDesenhoOrdenados()`/`desenhaObjetosNivel()` dentro de `paintComponent`) é pulada enquanto o timer está rodando, via novo método `deveDesenharObjetos()` (`!timerRedesenhoObjetosPosScroll.isRunning()`).
+- [x] 1.5 Testar manualmente: segurar uma seta por vários segundos, soltar, e confirmar que (a) fundo/traçado/painéis de info-controles não deixam artefato/smear durante o movimento, e (b) os objetos somem durante o movimento e reaparecem corretamente ~0,5s após soltar. *(confirmado manualmente pelo usuário.)*
+
+## 2. Tecla Delete na lista única de objetos
+
+- [x] 2.1 Extrair a lógica atual do `ActionListener` do botão "Remover" em `FormularioListaObjetos` (`defaultListModelOP.remove(sel); atualizarCircuito();`) para um método privado reutilizável (ex.: `removerObjetoSelecionado()`).
+- [x] 2.2 Em `iniciarComponentes()`, adicionar um `KeyAdapter` ao `JList list` que, ao receber `VK_DELETE` com um item selecionado, chama esse método (seguindo o padrão já usado em `pistaJList`/`boxJList`).
+- [x] 2.3 Garantir que Delete sem seleção na lista não lança exceção nem altera o estado (checar índice de seleção antes de remover).
+- [x] 2.4 Confirmar que esse novo caminho não interfere no `KeyAdapter` global de `EditorCircuitos`/`apagarObjetoSelecionado()` (fluxo de Delete via clique no canvas continua funcionando como antes). *(verificado por leitura: o `KeyAdapter` de `EditorCircuitos` está no `JFrame`, só recebe eventos quando o frame é o alvo do foco; o novo `KeyAdapter` está no `JList`, mesmo padrão isolado já usado por `pistaJList`/`boxJList`.)*
+
+## 3. Testes
+
+- [x] 3.1 Ajustar/adicionar testes de `MainPanelEditor` que cobrem `esquerda()/direita()/cima()/baixo()` para verificar o novo comportamento de debounce. *(reescrito em `MainPanelEditorScrollDebounceTest`: `repaint()` chamado em todo passo — via subclasse que conta chamadas —, timer compartilhado entre as 4 direções, e `deveDesenharObjetos()` — extraído e testado via reflection — `false` enquanto o timer está rodando.)*
+- [x] 3.2 Adicionar teste cobrindo Delete na lista única com item selecionado removendo o objeto correto da coleção do `Circuito` (`getObjetos()`/`getObjetosCenario()` conforme o tipo).
+- [x] 3.3 Adicionar teste cobrindo Delete na lista única sem seleção (nenhuma alteração, sem exceção).
+- [x] 3.4 Rodar `mvn test` e confirmar que a suíte completa passa sem abrir diálogos Swing reais (usar `MainPanelEditorTestDouble` quando aplicável, conforme `CLAUDE.md`).

--- a/openspec/specs/editor-lista-objetos-filtro-tipo/spec.md
+++ b/openspec/specs/editor-lista-objetos-filtro-tipo/spec.md
@@ -96,3 +96,18 @@ O checkbox "Somente Selecionado" do grupo 1 SHALL ficar desabilitado quando não
 #### Scenario: Checkboxes de tipo ficam desabilitados durante o modo
 - **WHEN** o modo "Somente Selecionado" está ativo
 - **THEN** os checkboxes de tipo do segundo grupo (e "Mostrar Todos"/"Mostrar Nenhum") ficam desabilitados, sem perder seus estados marcados/desmarcados anteriores
+
+### Requirement: Tecla Delete remove o objeto selecionado na lista única
+Com o foco na lista única de objetos (`FormularioListaObjetos`) e um item selecionado, pressionar a tecla Delete SHALL remover esse objeto, com o mesmo efeito do botão "Remover" já existente: o objeto é removido da coleção do `Circuito` correspondente ao seu tipo (`circuito.getObjetos()` ou `circuito.getObjetosCenario()`) e deixa de aparecer na lista e no desenho do circuito.
+
+#### Scenario: Delete com item selecionado remove o objeto
+- **WHEN** o usuário seleciona um objeto na lista única de objetos e pressiona a tecla Delete com o foco na lista
+- **THEN** o objeto selecionado é removido da coleção correspondente do `Circuito`, desaparece da lista única e deixa de ser desenhado no canvas
+
+#### Scenario: Delete sem seleção não tem efeito
+- **WHEN** o usuário pressiona a tecla Delete com o foco na lista única de objetos e nenhum item selecionado
+- **THEN** nenhum objeto é removido e a lista permanece inalterada
+
+#### Scenario: Delete na lista funciona mesmo sem seleção prévia no canvas
+- **WHEN** o usuário seleciona um objeto exclusivamente através da lista única (sem clicar nesse objeto no canvas) e pressiona Delete com o foco na lista
+- **THEN** o objeto é removido normalmente, independente do valor atual do campo de seleção usado pelo clique no canvas

--- a/openspec/specs/editor-scroll-atraso-desenho/spec.md
+++ b/openspec/specs/editor-scroll-atraso-desenho/spec.md
@@ -1,0 +1,34 @@
+# editor-scroll-atraso-desenho
+
+## Purpose
+
+Reduzir o custo de redesenho do editor de circuitos durante o pan por teclado (setas), suspendendo temporariamente o desenho da camada de objetos enquanto a viewport está em movimento, mantendo fundo, traçado e overlays fixos sempre atualizados a cada passo.
+
+## Requirements
+
+### Requirement: Redesenho dos objetos atrasado após pan por seta
+Ao mover a viewport do editor de circuitos pelas setas do teclado (sem modificadores, via `MainPanelEditor.esquerda()/direita()/cima()/baixo()`), o editor SHALL suspender o desenho da camada de objetos do circuito enquanto um passo de pan tiver ocorrido nos últimos 0,5 segundos, retomando o desenho dessa camada somente 0,5 segundos após o último passo de movimento. O restante do frame — cor de fundo, imagem de referência, traçado do circuito e os overlays fixos ao canto da viewport (painéis de informação/controles, posicionados a partir dos limites atuais da viewport) — SHALL continuar sendo redesenhado normalmente a cada passo de pan, sem esse atraso.
+
+#### Scenario: Um único passo de seta suspende o desenho dos objetos
+- **WHEN** o usuário pressiona uma seta de navegação uma única vez, movendo a viewport
+- **THEN** a camada de objetos do circuito não é desenhada nesse passo, e volta a ser desenhada somente 0,5 segundos depois, caso nenhum outro passo de pan ocorra nesse intervalo
+
+#### Scenario: Novos passos de pan reiniciam a contagem de 0,5 segundos
+- **WHEN** o usuário segura ou pressiona repetidamente as setas de navegação, gerando vários passos de pan em sequência com menos de 0,5 segundos entre eles
+- **THEN** a camada de objetos permanece sem ser desenhada durante essa sequência, voltando a ser desenhada uma única vez, 0,5 segundos após o último passo de pan
+
+#### Scenario: Direções diferentes de pan compartilham a mesma contagem
+- **WHEN** o usuário alterna entre setas de direções diferentes (por exemplo, direita e depois cima) sem pausa maior que 0,5 segundos entre os passos
+- **THEN** a suspensão do desenho dos objetos continua como uma única contagem contínua, sendo desfeita apenas 0,5 segundos após o último passo de pan em qualquer direção
+
+#### Scenario: Fundo, traçado e overlays fixos à viewport são redesenhados a cada passo, sem atraso
+- **WHEN** o usuário move a tela pelas setas, com a camada de objetos ainda suspensa pelo atraso
+- **THEN** a cor de fundo, a imagem de referência, o traçado do circuito e os overlays fixos ao canto da viewport são redesenhados corretamente a cada passo, refletindo a nova posição da viewport, sem esperar os 0,5 segundos
+
+#### Scenario: Overlays fixos à viewport não deixam artefato visual durante o pan
+- **WHEN** o usuário move a tela pelas setas em sequência (vários passos, com a camada de objetos suspensa)
+- **THEN** os overlays fixos ao canto da viewport (painéis de informação/controles) permanecem visualmente presos ao canto correto da área visível a cada passo, sem deixar cópias desatualizadas ou deslocadas sobre o fundo do circuito
+
+#### Scenario: Outras causas de redesenho não reiniciam a contagem de pan
+- **WHEN** ocorre um redesenho motivado por outra ação do editor que não seja o pan por seta (por exemplo, arrastar um objeto com o mouse, selecionar um item na lista de objetos, ou criar/editar um objeto)
+- **THEN** esse redesenho não reinicia nem altera a contagem de 0,5 segundos associada ao pan por seta

--- a/src/main/java/br/f1mane/editor/FormularioListaObjetos.java
+++ b/src/main/java/br/f1mane/editor/FormularioListaObjetos.java
@@ -3,6 +3,8 @@ package br.f1mane.editor;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.event.KeyAdapter;
+import java.awt.event.KeyEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.util.ArrayList;
@@ -200,11 +202,16 @@ public class FormularioListaObjetos {
 		remover.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
-				int sel = list.getSelectedIndex();
-				if (sel == -1)
-					return;
-				defaultListModelOP.remove(sel);
-				atualizarCircuito();
+				removerObjetoSelecionado();
+			}
+		});
+
+		list.addKeyListener(new KeyAdapter() {
+			@Override
+			public void keyPressed(KeyEvent e) {
+				if (e.getKeyCode() == KeyEvent.VK_DELETE) {
+					removerObjetoSelecionado();
+				}
 			}
 		});
 
@@ -313,6 +320,20 @@ public class FormularioListaObjetos {
 				defaultListModelOP.addElement(op);
 			}
 		}
+	}
+
+	/**
+	 * Remove o objeto atualmente selecionado na lista (usado tanto pelo botão
+	 * "Remover" quanto pela tecla Delete com foco na lista) — sem efeito se
+	 * não houver seleção.
+	 */
+	private void removerObjetoSelecionado() {
+		int sel = list.getSelectedIndex();
+		if (sel == -1) {
+			return;
+		}
+		defaultListModelOP.remove(sel);
+		atualizarCircuito();
 	}
 
 	protected void atualizarCircuito() {

--- a/src/main/java/br/f1mane/editor/MainPanelEditor.java
+++ b/src/main/java/br/f1mane/editor/MainPanelEditor.java
@@ -68,6 +68,7 @@ import javax.swing.ListCellRenderer;
 import javax.swing.SpinnerNumberModel;
 import javax.swing.SwingConstants;
 import javax.swing.SwingUtilities;
+import javax.swing.Timer;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import javax.swing.event.ListSelectionEvent;
@@ -162,6 +163,43 @@ public class MainPanelEditor extends JPanel {
     private JComboBox tipoNoCombo;
 
     private JScrollPane scrollPane;
+    /**
+     * Controla o adiamento do desenho da camada de objetos durante o pan por
+     * seta (ver {@link #esquerda()}/{@link #direita()}/{@link #cima()}/
+     * {@link #baixo()}): {@code paintComponent} só desenha os objetos do
+     * circuito quando este timer NÃO está rodando; cada passo de pan reinicia
+     * o timer (adiando o desenho dos objetos por mais 0,5s) mas continua
+     * chamando {@code repaint()} normalmente a cada passo, pra manter fundo,
+     * traçado e os overlays fixos ao canto da viewport (desenhaInfo/
+     * desenhaControles, posicionados via limitesViewPort()) sempre corretos —
+     * repintar tudo MENOS os objetos é barato; era só a iteração sobre os
+     * objetos que motivou o adiamento (ver design.md).
+     * <p>
+     * Antes desta versão, o repaint em si era pulado durante o pan: isso
+     * quebrava desenhaInfo/desenhaControles, porque eles não são conteúdo
+     * estático em coordenadas de circuito (que o blit-scroll da JViewport
+     * desloca corretamente) — são desenhados relativos à viewport atual, e
+     * ficavam "presos" na posição do frame anterior, arrastados pelo blit-
+     * scroll como um artefato visual sobre o fundo até o próximo repaint.
+     */
+    private final Timer timerRedesenhoObjetosPosScroll = criarTimerRedesenhoObjetosPosScroll();
+
+    private Timer criarTimerRedesenhoObjetosPosScroll() {
+        Timer timer = new Timer(500, e -> repaint());
+        timer.setRepeats(false);
+        return timer;
+    }
+
+    /** Chamado a cada passo de pan por seta: adia o desenho dos objetos por mais 0,5s e repinta o resto do frame normalmente. */
+    private void iniciarOuEstenderDebounceRedesenhoPosScroll() {
+        timerRedesenhoObjetosPosScroll.restart();
+        repaint();
+    }
+
+    /** {@code paintComponent} só desenha a camada de objetos quando não há um gesto de pan por seta em andamento. */
+    private boolean deveDesenharObjetos() {
+        return !timerRedesenhoObjetosPosScroll.isRunning();
+    }
 
     public final double zoom = 1;
     private BufferedImage carroCima;
@@ -1597,7 +1635,7 @@ public class MainPanelEditor extends JPanel {
                     return;
                 }
                 p.x -= 40;
-                repaint();
+                iniciarOuEstenderDebounceRedesenhoPosScroll();
                 scrollPane.getViewport().setViewPosition(p);
             }
         });
@@ -1612,7 +1650,7 @@ public class MainPanelEditor extends JPanel {
                     return;
                 }
                 p.x += 40;
-                repaint();
+                iniciarOuEstenderDebounceRedesenhoPosScroll();
                 scrollPane.getViewport().setViewPosition(p);
 
             }
@@ -1628,7 +1666,7 @@ public class MainPanelEditor extends JPanel {
                     return;
                 }
                 p.y -= 40;
-                repaint();
+                iniciarOuEstenderDebounceRedesenhoPosScroll();
                 scrollPane.getViewport().setViewPosition(p);
 
             }
@@ -1645,7 +1683,7 @@ public class MainPanelEditor extends JPanel {
                     return;
                 }
                 p.y += 40;
-                repaint();
+                iniciarOuEstenderDebounceRedesenhoPosScroll();
                 scrollPane.getViewport().setViewPosition(p);
 
             }
@@ -3124,11 +3162,20 @@ public class MainPanelEditor extends JPanel {
         // chamada de niveisDesenhoOrdenados()/desenhaObjetosNivel(), como
         // antes) evita realocar/concatenar objetos+objetosCenario várias
         // vezes por frame — ver design.md, decisão de performance.
-        List<ObjetoPista> todosOsObjetos = todosObjetos();
-        List<Integer> niveis = niveisDesenhoOrdenados(todosOsObjetos);
-        for (Integer nivel : niveis) {
-            if (nivel < 0) {
-                desenhaObjetosNivel(g2d, nivel, todosOsObjetos);
+        //
+        // desenharObjetos == false durante um gesto de pan por seta em
+        // andamento (ver timerRedesenhoObjetosPosScroll): pula a iteração
+        // sobre todos os objetos do circuito, que é o custo que motivou o
+        // adiamento. O resto do frame (fundo, traçado, overlays fixos à
+        // viewport) continua sendo desenhado normalmente a cada repaint.
+        boolean desenharObjetos = deveDesenharObjetos();
+        List<ObjetoPista> todosOsObjetos = desenharObjetos ? todosObjetos() : Collections.emptyList();
+        List<Integer> niveis = desenharObjetos ? niveisDesenhoOrdenados(todosOsObjetos) : Collections.emptyList();
+        if (desenharObjetos) {
+            for (Integer nivel : niveis) {
+                if (nivel < 0) {
+                    desenhaObjetosNivel(g2d, nivel, todosOsObjetos);
+                }
             }
         }
 
@@ -3142,16 +3189,20 @@ public class MainPanelEditor extends JPanel {
         DesenhoProceduralCircuito.desenhaLinhaDeLargada(g2d, circuito, zoom);
         desenhaGrid(g2d);
         desenhaBoxes(g2d);
-        desenhaObjetosNivel(g2d, 0, todosOsObjetos);
+        if (desenharObjetos) {
+            desenhaObjetosNivel(g2d, 0, todosOsObjetos);
+        }
         desenhaPreObjetoLivre(g2d);
         desenhaPreObjetoGuardRails(g2d);
         desenhaPreObjetoArquibancada(g2d);
         desenhaPreObjetoEscapada(g2d);
         desenhaPreObjetoTransparencia(g2d);
         // Níveis positivos por cima, do menor para o maior (mais em cima).
-        for (Integer nivel : niveis) {
-            if (nivel > 0) {
-                desenhaObjetosNivel(g2d, nivel, todosOsObjetos);
+        if (desenharObjetos) {
+            for (Integer nivel : niveis) {
+                if (nivel > 0) {
+                    desenhaObjetosNivel(g2d, nivel, todosOsObjetos);
+                }
             }
         }
         desenhaMarcadoresEdicaoPontos(g2d);

--- a/src/test/java/br/f1mane/editor/FormularioListaObjetosUnificadaTest.java
+++ b/src/test/java/br/f1mane/editor/FormularioListaObjetosUnificadaTest.java
@@ -5,11 +5,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.awt.Component;
 import java.awt.Container;
+import java.awt.event.KeyEvent;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 
 import javax.swing.JButton;
+import javax.swing.JList;
 
 import org.junit.jupiter.api.Test;
 
@@ -123,6 +125,64 @@ class FormularioListaObjetosUnificadaTest {
 
         assertTrue(circuito.getObjetosCenario().isEmpty());
         assertEquals(List.of(f1), circuito.getObjetos());
+    }
+
+    @Test
+    void deleteNaLista_comSelecao_removeDaColecaoCorreta() {
+        MainPanelEditor editor = new MainPanelEditor();
+        Circuito circuito = new Circuito();
+        ObjetoLivre c1 = objetoLivre("C1");
+        ObjetoEscapada f1 = objetoEscapada("F1");
+        circuito.setObjetosCenario(new ArrayList<>(List.of(c1)));
+        circuito.setObjetos(new ArrayList<>(List.of(f1)));
+        editor.setCircuito(circuito);
+
+        FormularioListaObjetos formulario = FormularioListaObjetos.unificada(editor);
+        formulario.listarObjetos();
+        formulario.selecaoProgramatica = true;
+        try {
+            formulario.getList().setSelectedIndex(0);
+        } finally {
+            formulario.selecaoProgramatica = false;
+        }
+
+        pressionarDelete(formulario.getList());
+
+        assertTrue(circuito.getObjetosCenario().isEmpty());
+        assertEquals(List.of(f1), circuito.getObjetos());
+    }
+
+    @Test
+    void deleteNaLista_semSelecao_naoAlteraNada() {
+        MainPanelEditor editor = new MainPanelEditor();
+        Circuito circuito = new Circuito();
+        ObjetoLivre c1 = objetoLivre("C1");
+        circuito.setObjetosCenario(new ArrayList<>(List.of(c1)));
+        circuito.setObjetos(new ArrayList<>());
+        editor.setCircuito(circuito);
+
+        FormularioListaObjetos formulario = FormularioListaObjetos.unificada(editor);
+        formulario.listarObjetos();
+
+        pressionarDelete(formulario.getList());
+
+        assertEquals(List.of(c1), circuito.getObjetosCenario());
+        assertEquals(1, formulario.getDefaultListModelOP().getSize());
+    }
+
+    /**
+     * Invoca diretamente os KeyListener registrados na lista, em vez de
+     * {@code dispatchEvent} — em ambiente headless (sem foco/peer real), o
+     * roteamento padrão de KeyEvent via KeyboardFocusManager não entrega o
+     * evento aos listeners, então chamamos {@code keyPressed} diretamente,
+     * como o próprio AWT faria internamente com um componente focado.
+     */
+    private static void pressionarDelete(JList lista) {
+        KeyEvent evento = new KeyEvent(lista, KeyEvent.KEY_PRESSED, System.currentTimeMillis(), 0,
+                KeyEvent.VK_DELETE, KeyEvent.CHAR_UNDEFINED);
+        for (java.awt.event.KeyListener listener : lista.getKeyListeners()) {
+            listener.keyPressed(evento);
+        }
     }
 
     @Test

--- a/src/test/java/br/f1mane/editor/MainPanelEditorScrollDebounceTest.java
+++ b/src/test/java/br/f1mane/editor/MainPanelEditorScrollDebounceTest.java
@@ -1,0 +1,141 @@
+package br.f1mane.editor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.awt.Point;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+import javax.swing.JScrollPane;
+import javax.swing.SwingUtilities;
+import javax.swing.Timer;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pan por seta (esquerda/direita/cima/baixo) não redesenha a camada de
+ * objetos a cada passo: um único javax.swing.Timer (0,5s, não repetitivo),
+ * compartilhado entre as quatro direções, é reiniciado a cada passo, e
+ * {@code paintComponent} só desenha os objetos do circuito quando esse timer
+ * NÃO está rodando ({@link MainPanelEditor#deveDesenharObjetos()}).
+ * <p>
+ * Diferente de uma primeira versão desta feature: o {@code repaint()} em si
+ * NÃO é pulado durante o pan — é chamado a cada passo, normalmente. Pular o
+ * repaint quebrava desenhaInfo()/desenhaControles() (overlays fixos ao canto
+ * da viewport, recalculados a cada frame a partir de limitesViewPort()):
+ * como eles não são conteúdo estático em coordenadas de circuito, o
+ * blit-scroll da JViewport arrastava a posição desenhada no frame anterior
+ * junto com o resto do canvas, em vez de mantê-los presos ao canto — um
+ * artefato visual sobre o fundo. Só a iteração sobre os objetos do circuito
+ * (o custo que motivou o adiamento) é pulada durante o gesto; o resto do
+ * frame é redesenhado normalmente a cada passo.
+ */
+class MainPanelEditorScrollDebounceTest {
+
+    private static class EditorComContadorDeRepaint extends MainPanelEditor {
+        int repaints;
+
+        @Override
+        public void repaint() {
+            repaints++;
+        }
+    }
+
+    /**
+     * Monta o scrollPane com {@code editor} como view (como em produção,
+     * {@code gerarLayout}) — sem uma view real, {@code JViewport} não tem
+     * como calcular {@code getViewSize()} e clampa qualquer
+     * {@code setViewPosition} de volta pra (0,0).
+     */
+    private static void configuraViewport(MainPanelEditor editor) throws Exception {
+        editor.setPreferredSize(new java.awt.Dimension(10000, 10000));
+        JScrollPane scrollPane = new JScrollPane(editor, JScrollPane.VERTICAL_SCROLLBAR_NEVER,
+                JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
+        scrollPane.getViewport().setSize(400, 400);
+        scrollPane.getViewport().setViewPosition(new Point(100, 100));
+        Field campo = MainPanelEditor.class.getDeclaredField("scrollPane");
+        campo.setAccessible(true);
+        campo.set(editor, scrollPane);
+    }
+
+    private static Timer timerDebounce(MainPanelEditor editor) throws Exception {
+        Field campo = MainPanelEditor.class.getDeclaredField("timerRedesenhoObjetosPosScroll");
+        campo.setAccessible(true);
+        return (Timer) campo.get(editor);
+    }
+
+    private static boolean deveDesenharObjetos(MainPanelEditor editor) throws Exception {
+        Method metodo = MainPanelEditor.class.getDeclaredMethod("deveDesenharObjetos");
+        metodo.setAccessible(true);
+        return (Boolean) metodo.invoke(editor);
+    }
+
+    /** Roda um Runnable na EDT e drena a fila (inclusive invokeLater aninhado, como o de esquerda()/direita()/...). */
+    private static void executarEDrenarEdt(Runnable acao) throws Exception {
+        SwingUtilities.invokeAndWait(acao::run);
+        SwingUtilities.invokeAndWait(() -> {
+        });
+    }
+
+    @Test
+    void esquerda_moveViewportImediatamenteEIniciaDebounceDosObjetos() throws Exception {
+        MainPanelEditor editor = new MainPanelEditor();
+        configuraViewport(editor);
+        Timer timer = timerDebounce(editor);
+        assertFalse(timer.isRunning(), "timer não deveria estar rodando antes de qualquer pan");
+        assertTrue(deveDesenharObjetos(editor), "sem pan em andamento, os objetos devem ser desenhados normalmente");
+
+        executarEDrenarEdt(editor::esquerda);
+
+        Field scrollPaneField = MainPanelEditor.class.getDeclaredField("scrollPane");
+        scrollPaneField.setAccessible(true);
+        JScrollPane scrollPane = (JScrollPane) scrollPaneField.get(editor);
+        assertEquals(60, scrollPane.getViewport().getViewPosition().x,
+                "viewport deve se mover imediatamente (100 - 40)");
+
+        assertTrue(timer.isRunning(), "pan por seta deve iniciar o timer de debounce dos objetos");
+        assertEquals(500, timer.getDelay(), "atraso do redesenho dos objetos deve ser de 0,5 segundos");
+        assertFalse(timer.isRepeats(), "o redesenho dos objetos deve disparar uma única vez por período de pan parado");
+        assertFalse(deveDesenharObjetos(editor), "com o pan em andamento, o desenho dos objetos deve ficar suspenso");
+    }
+
+    @Test
+    void passosSucessivosDePan_compartilhamOMesmoTimerEContinuamAgendados() throws Exception {
+        MainPanelEditor editor = new MainPanelEditor();
+        configuraViewport(editor);
+        Timer timer = timerDebounce(editor);
+
+        executarEDrenarEdt(editor::direita);
+        assertTrue(timer.isRunning());
+
+        executarEDrenarEdt(editor::cima);
+        Timer timerAposSegundoPasso = timerDebounce(editor);
+        assertTrue(timerAposSegundoPasso == timer, "as quatro direções devem compartilhar a mesma instância de timer");
+        assertTrue(timerAposSegundoPasso.isRunning(), "um novo passo de pan deve manter o timer agendado (restart), não deixá-lo expirar");
+        assertFalse(deveDesenharObjetos(editor), "objetos continuam suspensos enquanto o gesto está em andamento");
+    }
+
+    @Test
+    void todoPassoDePan_repintaOFrameNormalmente() throws Exception {
+        // repaint() precisa ser chamado a cada passo (não só no primeiro) —
+        // é o que mantém desenhaInfo()/desenhaControles() presos ao canto da
+        // viewport a cada frame, evitando o artefato descrito na classe.
+        EditorComContadorDeRepaint editor = new EditorComContadorDeRepaint();
+        configuraViewport(editor);
+        int antesDoGesto = editor.repaints;
+
+        executarEDrenarEdt(editor::esquerda);
+        assertEquals(antesDoGesto + 1, editor.repaints, "primeiro passo do gesto deve repintar o frame");
+
+        executarEDrenarEdt(editor::direita);
+        assertEquals(antesDoGesto + 2, editor.repaints, "passos seguintes do mesmo gesto também devem repintar o frame");
+    }
+
+    @Test
+    void timerNaoRodando_deveDesenharObjetosEhVerdadeiro() throws Exception {
+        MainPanelEditor editor = new MainPanelEditor();
+        assertTrue(deveDesenharObjetos(editor));
+    }
+}


### PR DESCRIPTION
Segurar as setas no editor de circuitos redesenhava todos os objetos a cada passo de pan; agora o desenho da camada de objetos fica suspenso por 0,5s após o último passo (fundo, traçado e overlays fixos à viewport continuam atualizados a cada frame, evitando artefatos). Tecla Delete na lista única de objetos passa a remover o item selecionado, mesmo sem seleção prévia no canvas.